### PR TITLE
Don't leak custom types in solders-traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # [0.11.0] - Unreleased
 
 - Move solders-macros into the monorepo [(#22)](https://github.com/kevinheavey/solders/pull/22)
-- Extract solders-primitives into its own crate [(#23)](https://github.com/kevinheavey/solders/pull/23)
+- Extract solders-primitives into its own crate [(#24)](https://github.com/kevinheavey/solders/pull/24)
+- Don't leak custom error types in solders-traits; use ValueError instead [(#25)](https://github.com/kevinheavey/solders/pull/25)
 
 ## [0.10.0] - 2022-10-31
 

--- a/src/rpc/requests.rs
+++ b/src/rpc/requests.rs
@@ -1,9 +1,7 @@
 #![allow(deprecated)]
-use crate::{
-    commitment_config::{CommitmentConfig, CommitmentLevel},
-};
+use crate::commitment_config::{CommitmentConfig, CommitmentLevel};
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple, PyTypeInfo};
-use solders_primitives::{message::Message, transaction::Transaction, pubkey::Pubkey};
+use solders_primitives::{message::Message, pubkey::Pubkey, transaction::Transaction};
 use solders_traits::{
     py_from_bytes_general_via_cbor, pybytes_general_via_cbor, to_py_err, CommonMethods,
     PyBytesCbor, PyFromBytesCbor, RichcmpEqualityOnly,

--- a/tests/test_instruction.py
+++ b/tests/test_instruction.py
@@ -62,7 +62,7 @@ def test_compiled_accounts_eq(compiled_ix: CompiledInstruction) -> None:
 
 @mark.parametrize("to_deserialize", [Instruction, CompiledInstruction])
 def test_bincode_error(to_deserialize: Union[Instruction, CompiledInstruction]) -> None:
-    with raises(BincodeError) as excinfo:
+    with raises(ValueError) as excinfo:
         Instruction.from_bytes(b"foo")
     assert excinfo.value.args[0] == "io error: unexpected end of file"
 

--- a/tests/test_instruction.py
+++ b/tests/test_instruction.py
@@ -3,7 +3,6 @@ from typing import cast, Union
 from pytest import mark, raises, fixture
 from solders.instruction import Instruction, CompiledInstruction, AccountMeta
 from solders.pubkey import Pubkey
-from solders.errors import BincodeError
 
 
 @fixture

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -393,7 +393,7 @@ macro_rules! py_from_bytes_general_via_bincode {
 pub trait PyFromBytesBincode<'b>: Deserialize<'b> {
     fn py_from_bytes_bincode(raw: &'b [u8]) -> PyResult<Self> {
         let deser = bincode::deserialize::<Self>(raw);
-        handle_py_err(deser)
+        handle_py_value_err(deser)
     }
 }
 
@@ -408,7 +408,7 @@ macro_rules! py_from_bytes_general_via_cbor {
 pub trait PyFromBytesCbor<'b>: Deserialize<'b> {
     fn py_from_bytes_cbor(raw: &'b [u8]) -> PyResult<Self> {
         let deser = serde_cbor::from_slice::<Self>(raw);
-        handle_py_err(deser)
+        handle_py_value_err(deser)
     }
 }
 
@@ -454,6 +454,6 @@ pub trait CommonMethods<'a>:
     }
 
     fn py_from_json(raw: &'a str) -> PyResult<Self> {
-        serde_json::from_str(raw).map_err(to_py_err)
+        serde_json::from_str(raw).map_err(|e| to_py_value_err(&e))
     }
 }


### PR DESCRIPTION
Use ValueError instead of custom errors like SerdeJSONError. These types don't work properly in other packages. See https://github.com/PyO3/pyo3/issues/1444