### PR TITLE
Fix transaction.Legacy equality checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,5 @@ docs/_build/
 # PyCharm
 .idea/
 
-# VSCode
-.vscode/
-
 # Pyenv
 .python-version

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.formatting.provider": "black",
+    "rust-analyzer.cargo.features": "all"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.14.4] - 2023-02-22
+
+### Fixed
+
+`transaction.Legacy` no longer implicitly casts to int when checking equality. This was breaking tx version checking when tx version was returned as `Legacy | int` [(#44)](https://github.com/kevinheavey/solders/pull/44
+
 ## [0.14.3] - 2023-01-28
 
 ### Fixed 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -720,6 +720,8 @@ impl RichcmpEqualityOnly for Legacy {}
 #[pymethods]
 impl Legacy {
     fn __richcmp__(&self, other: &Self, op: pyo3::basic::CompareOp) -> pyo3::prelude::PyResult<bool> {
+        // we override the default impl since it implicitly casts to in which causes problems when transaction
+        // version is represented as `Legacy | int`.
         solders_traits::RichcmpEqualityOnly::richcmp(self, other, op)
     }
 }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -715,6 +715,15 @@ pub enum Legacy {
     Legacy,
 }
 
+impl RichcmpEqualityOnly for Legacy {}
+
+#[pymethods]
+impl Legacy {
+    fn __richcmp__(&self, other: &Self, op: pyo3::basic::CompareOp) -> pyo3::prelude::PyResult<bool> {
+        solders_traits::RichcmpEqualityOnly::richcmp(self, other, op)
+    }
+}
+
 impl From<Legacy> for LegacyOriginal {
     fn from(x: Legacy) -> Self {
         match x {

--- a/tests/test_versioned_transaction.py
+++ b/tests/test_versioned_transaction.py
@@ -13,7 +13,7 @@ from solders.system_program import (
     transfer,
     withdraw_nonce_account,
 )
-from solders.transaction import Transaction, VersionedTransaction
+from solders.transaction import Transaction, VersionedTransaction, Legacy
 
 
 def test_try_new() -> None:
@@ -152,3 +152,8 @@ def test_partial_signing() -> None:
     assert deserialized.signatures == fully_signed.signatures
     assert deserialized == fully_signed
     assert bytes(deserialized) == bytes(fully_signed)
+
+def test_legacy_version() -> None:
+    assert Legacy.Legacy == Legacy.Legacy
+    assert Legacy.Legacy != 0 # we don't want implicit int conversion because it clashes with versioned transaction versions
+    assert isinstance(Legacy.Legacy, Legacy)

--- a/tests/test_versioned_transaction.py
+++ b/tests/test_versioned_transaction.py
@@ -13,7 +13,7 @@ from solders.system_program import (
     transfer,
     withdraw_nonce_account,
 )
-from solders.transaction import Transaction, VersionedTransaction, Legacy
+from solders.transaction import Legacy, Transaction, VersionedTransaction
 
 
 def test_try_new() -> None:

--- a/tests/test_versioned_transaction.py
+++ b/tests/test_versioned_transaction.py
@@ -150,3 +150,5 @@ def test_partial_signing() -> None:
     deserialized.signatures = sigs
     fully_signed = VersionedTransaction(message, [keypair0, keypair1])
     assert deserialized.signatures == fully_signed.signatures
+    assert deserialized == fully_signed
+    assert bytes(deserialized) == bytes(fully_signed)


### PR DESCRIPTION
Don't implicitly cast to int anymore. This addresses one of the problems in #43 