### PR TITLE
Avoid panic in `Keypair.from_base58_string`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   name: solders
-  python_version: "3.7"
+  python_version: "3.8"
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-D warnings"
   maturin_version: "0.14.10"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   macos_x86_64:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -41,7 +41,7 @@ jobs:
           pytest
 
   macos_universal2:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.21.1] - Unreleased
+
+- Avoid panic in `Keypair.from_base58_string` [(#93)](https://github.com/kevinheavey/solders/pull/93).
+
 ## [0.21.0] - 2024-03-13
 
 ### Changed

--- a/tests/test_keypair.py
+++ b/tests/test_keypair.py
@@ -40,6 +40,10 @@ def test_str() -> None:
     assert str(kp) == expected
     assert Keypair.from_base58_string(expected) == kp
 
+def test_bad_str() -> None:
+    raw = "foo"
+    with raises(ValueError):
+        Keypair.from_base58_string(raw)
 
 def test_sign_message() -> None:
     seed = bytes([1] * 32)


### PR DESCRIPTION
Fixes #91 