### PR TITLE
feat: re-add pickle support for Pubkey, Hash, and Signature

### DIFF
--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -128,6 +128,10 @@ impl Hash {
     pub fn from_bytes(raw_bytes: [u8; HASH_BYTES]) -> PyResult<Self> {
         Self::py_from_bytes(&raw_bytes)
     }
+
+    fn __getnewargs__(&self) -> ([u8; HASH_BYTES],) {
+        (self.0.to_bytes(),)
+    }
 }
 
 impl PyFromBytesGeneral for Hash {

--- a/crates/pubkey/src/lib.rs
+++ b/crates/pubkey/src/lib.rs
@@ -237,6 +237,10 @@ impl Pubkey {
     pub fn from_bytes(raw: &[u8]) -> PyResult<Self> {
         Self::py_from_bytes(raw)
     }
+
+    fn __getnewargs__(&self) -> ([u8; PUBKEY_BYTES],) {
+        (self.0.to_bytes(),)
+    }
 }
 
 impl RichcmpFull for Pubkey {}

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -144,6 +144,10 @@ impl Signature {
     pub fn from_bytes(raw_bytes: [u8; Self::LENGTH]) -> PyResult<Self> {
         Self::py_from_bytes(&raw_bytes)
     }
+
+    fn __getnewargs__(&self) -> ([u8; SIGNATURE_BYTES],) {
+        (self.to_bytes(),)
+    }
 }
 
 impl PyHash for Signature {}

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,3 +1,5 @@
+import pickle
+
 from based58 import b58encode
 from pytest import mark, raises
 from solders.hash import Hash, ParseHashError
@@ -46,3 +48,8 @@ def test_hashable() -> None:
 def test_json() -> None:
     obj = Hash.default()
     assert Hash.from_json(obj.to_json()) == obj
+
+
+def test_pickle() -> None:
+    obj = Hash.default()
+    assert pickle.loads(pickle.dumps(obj)) == obj

--- a/tests/test_pubkey.py
+++ b/tests/test_pubkey.py
@@ -1,3 +1,5 @@
+import pickle
+
 from pytest import mark, raises
 from solders.pubkey import Pubkey
 
@@ -136,4 +138,11 @@ def test_json() -> None:
     key = Pubkey.new_unique()
     ser = key.to_json()
     deser = Pubkey.from_json(ser)
+    assert deser == key
+
+
+def test_pickle() -> None:
+    key = Pubkey.new_unique()
+    ser = pickle.dumps(key)
+    deser = pickle.loads(ser)
     assert deser == key

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,3 +1,5 @@
+import pickle
+
 from based58 import b58decode, b58encode
 from pytest import fixture, raises
 from solders.keypair import Keypair
@@ -88,3 +90,8 @@ def test_from_bytes() -> None:
 def test_json() -> None:
     obj = Signature.default()
     assert Signature.from_json(obj.to_json()) == obj
+
+
+def test_pickle() -> None:
+    obj = Signature.default()
+    assert pickle.loads(pickle.dumps(obj)) == obj


### PR DESCRIPTION
Pickle support was removed in v0.25.0 when upgrading to pyo3 0.23 due to breaking API changes in the old `__reduce__` implementation.

This PR restores pickle support using the `__getnewargs__` protocol, which is simpler and more idiomatic for immutable byte-wrapper types. This approach is fully compatible with pyo3 0.23+ and avoids deprecated APIs like `IntoPy` and `Python::acquire_gil()`.

## Changes
- Add `__getnewargs__` method to Pubkey, Hash, and Signature
- Re-add pickle tests for all three types
- All 35 existing tests pass ✅

## Implementation Details
The implementation leverages the immutable nature of these types (glorified byte wrappers), returning their byte representation directly to pickle for reconstruction via `__new__`. This is much simpler than the old `__reduce__` approach and doesn't require any manual class lookup or deprecated pyo3 APIs.

## Testing
```bash
uv run pytest tests/test_pubkey.py::test_pickle tests/test_hash.py::test_pickle tests/test_signature.py::test_pickle -v
# All tests PASSED
```