### PR TITLE
feat: add __deepcopy__ code methods 

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -104,6 +104,10 @@ fn add_core_methods(ast: &mut ItemImpl) {
         ImplItem::Verbatim(quote! { pub fn __repr__(&self) -> String {
             solders_traits_core::CommonMethodsCore::pyrepr(self)
         } }),
+        ImplItem::Verbatim(quote! {
+            pub fn __deepcopy__(&self, _memo: &Bound<'_, pyo3::types::PyAny>) -> Self {
+            solders_traits_core::CommonMethodsCore::py_deepcopy(self)
+        } }),
     ];
     if !ast.items.iter().any(|item| match item {
         ImplItem::Method(m) => m.sig.ident == "from_bytes",
@@ -127,7 +131,7 @@ fn add_core_methods(ast: &mut ItemImpl) {
     ast.items.extend_from_slice(&methods);
 }
 
-/// Add `__bytes__`, `__str__`, and `__repr__` using the `CommonMethodsCore` trait.
+/// Add `__bytes__`, `__str__`, `__deepcopy__`, and `__repr__` using the `CommonMethodsCore` trait.
 ///
 /// Also add `from_bytes` if not already defined.
 #[proc_macro_attribute]
@@ -137,7 +141,7 @@ pub fn common_methods_core(_: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, `to_json` and `from_json` using the `CommonMethods` trait.
+/// Add `__bytes__`, `__str__`, `__deepcopy__`, `__repr__`, `to_json` and `from_json` using the `CommonMethods` trait.
 ///
 /// Also add `from_bytes` if not already defined.
 #[proc_macro_attribute]
@@ -160,7 +164,7 @@ pub fn common_methods(_: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, and `to_json` using the `CommonMethods` trait.
+/// Add `__bytes__`, `__str__`, `__deepcopy__`, `__repr__`, and `to_json` using the `CommonMethods` trait.
 ///
 /// Also add `from_bytes` if not already defined.
 #[proc_macro_attribute]
@@ -176,7 +180,7 @@ pub fn common_methods_ser_only(_: TokenStream, item: TokenStream) -> TokenStream
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, `__reduce__`, `to_json`, `from_json`, `from_bytes` and `__richcmp__` using the `CommonMethodsRpcResp` trait.
+/// Add `__bytes__`, `__str__`, `__deepcopy__`, `__repr__`, `__reduce__`, `to_json`, `from_json`, `from_bytes` and `__richcmp__` using the `CommonMethodsRpcResp` trait.
 #[proc_macro_attribute]
 pub fn common_methods_rpc_resp(_: TokenStream, item: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(item as ItemImpl);

--- a/crates/traits-core/src/lib.rs
+++ b/crates/traits-core/src/lib.rs
@@ -227,6 +227,10 @@ pub trait CommonMethodsCore:
     fn py_from_bytes(raw: &[u8]) -> PyResult<Self> {
         <Self as PyFromBytesGeneral>::py_from_bytes_general(raw)
     }
+
+    fn py_deepcopy(&self) -> Self {
+        self.clone()
+    }
 }
 
 pub trait CommonMethodsSerOnly<'a>: CommonMethodsCore + Serialize {

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -1,0 +1,25 @@
+import copy
+from typing import Any
+import pytest
+from solders.account import Account
+from solders.pubkey import Pubkey
+from solders.hash import Hash
+from solders.signature import Signature
+from solders.message import Message
+
+
+objects_to_copy = [
+    Account.default(),
+    Pubkey.default(),
+    Hash.default(),
+    Signature.default(),
+    Message.default(),
+]
+
+
+@pytest.mark.parametrize("original", objects_to_copy)
+def test_deepcopy(original: Any) -> None:
+    copied = copy.deepcopy(original)
+
+    assert copied == original
+    assert id(copied) != id(original)


### PR DESCRIPTION
This PR adds `__deepcopy__` to `add_core_methods`.

This feature is useful to me because version `0.25` removed support for `pickle` and now `copy.deepcopy` is not working OOTB, this is a compromise that would let users keep using `copy.deepcopy` without reintroducing pickle.