### PR TITLE
Restore pickle and deepcopy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# Unreleased
+
+### Added
+
+- Restored pickle and `copy.deepcopy` support: a `__reduce__` method is now generated for all types using the `common_methods` family of macros (reconstructing via `from_bytes(bytes(self))`).
+
+### Fixed
+
+- `Rent` declared `module = "solders.account"` but is exported from `solders.rent`, which broke pickling.
+
 # [0.27.1] 2025-11-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Restored pickle and `copy.deepcopy` support: a `__reduce__` method is now generated for all types using the `common_methods` family of macros (reconstructing via `from_bytes(bytes(self))`).
+- `copy.deepcopy` support for RPC response types (via a clone-based `__deepcopy__`; these don't support pickle because their bincode round-trip is broken by `skip_serializing_if`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - `Rent` declared `module = "solders.account"` but is exported from `solders.rent`, which broke pickling.
+- `EncodedConfirmedTransactionWithStatusMeta` now serializes its bytes via CBOR instead of bincode. Its `bytes()`/`from_bytes` were broken (bincode can't represent the `#[serde(flatten)]` field), which also broke pickle and deepcopy for it.
 
 # [0.27.1] 2025-11-15
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -197,7 +197,7 @@ pub fn common_methods_ser_only(_: TokenStream, item: TokenStream) -> TokenStream
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, `to_json`, `from_json`, `from_bytes` and `__richcmp__` using the `CommonMethodsRpcResp` trait.
+/// Add `__bytes__`, `__str__`, `__repr__`, `__deepcopy__`, `to_json`, `from_json`, `from_bytes` and `__richcmp__` using the `CommonMethodsRpcResp` trait.
 #[proc_macro_attribute]
 pub fn common_methods_rpc_resp(_: TokenStream, item: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(item as ItemImpl);
@@ -247,6 +247,14 @@ pub fn common_methods_rpc_resp(_: TokenStream, item: TokenStream) -> TokenStream
                 solders_traits_core::RichcmpEqualityOnly::richcmp(self, other, op)
             }},
         ),
+        // Response types can't use the `from_bytes`-based `__reduce__` (their
+        // bincode round-trip is broken by `skip_serializing_if`), so support
+        // `copy.deepcopy` directly via clone.
+        ImplItem::Verbatim(quote! {
+            pub fn __deepcopy__(&self, _memo: &pyo3::Bound<'_, pyo3::types::PyAny>) -> Self {
+                self.clone()
+            }
+        }),
     ];
     ast.items.extend_from_slice(&methods);
     TokenStream::from(ast.to_token_stream())

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -93,6 +93,26 @@ pub fn richcmp_signer(_: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(ast.to_token_stream())
 }
 
+/// Build a ``__reduce__`` method enabling pickle (and, by extension, ``copy.deepcopy``).
+///
+/// It reconstructs the object via ``from_bytes(bytes(self))``, relying only on the
+/// Python-level ``__bytes__`` and ``from_bytes`` methods, so it works for any type
+/// that has both regardless of which trait provides them.
+fn reduce_method() -> ImplItem {
+    ImplItem::Verbatim(quote! {
+        pub fn __reduce__<'py>(
+            slf: &pyo3::Bound<'py, Self>,
+        ) -> pyo3::PyResult<(
+            pyo3::Bound<'py, pyo3::types::PyAny>,
+            (pyo3::Bound<'py, pyo3::types::PyBytes>,),
+        )> {
+            let constructor = slf.get_type().getattr("from_bytes")?;
+            let data: Vec<u8> = slf.call_method0("__bytes__")?.extract()?;
+            Ok((constructor, (pyo3::types::PyBytes::new(slf.py(), &data),)))
+        }
+    })
+}
+
 fn add_core_methods(ast: &mut ItemImpl) {
     let mut methods = vec![
         ImplItem::Verbatim(quote! {pub fn __bytes__<'a>(&self) -> Vec<u8>  {
@@ -104,6 +124,7 @@ fn add_core_methods(ast: &mut ItemImpl) {
         ImplItem::Verbatim(quote! { pub fn __repr__(&self) -> String {
             solders_traits_core::CommonMethodsCore::pyrepr(self)
         } }),
+        reduce_method(),
     ];
     if !ast.items.iter().any(|item| match item {
         ImplItem::Method(m) => m.sig.ident == "from_bytes",
@@ -127,7 +148,7 @@ fn add_core_methods(ast: &mut ItemImpl) {
     ast.items.extend_from_slice(&methods);
 }
 
-/// Add `__bytes__`, `__str__`, and `__repr__` using the `CommonMethodsCore` trait.
+/// Add `__bytes__`, `__str__`, `__repr__`, and `__reduce__` using the `CommonMethodsCore` trait.
 ///
 /// Also add `from_bytes` if not already defined.
 #[proc_macro_attribute]
@@ -137,7 +158,7 @@ pub fn common_methods_core(_: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, `to_json` and `from_json` using the `CommonMethods` trait.
+/// Add `__bytes__`, `__str__`, `__repr__`, `__reduce__`, `to_json` and `from_json` using the `CommonMethods` trait.
 ///
 /// Also add `from_bytes` if not already defined.
 #[proc_macro_attribute]
@@ -160,7 +181,7 @@ pub fn common_methods(_: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, and `to_json` using the `CommonMethods` trait.
+/// Add `__bytes__`, `__str__`, `__repr__`, `__reduce__`, and `to_json` using the `CommonMethods` trait.
 ///
 /// Also add `from_bytes` if not already defined.
 #[proc_macro_attribute]
@@ -176,7 +197,7 @@ pub fn common_methods_ser_only(_: TokenStream, item: TokenStream) -> TokenStream
     TokenStream::from(ast.to_token_stream())
 }
 
-/// Add `__bytes__`, `__str__`, `__repr__`, `__reduce__`, `to_json`, `from_json`, `from_bytes` and `__richcmp__` using the `CommonMethodsRpcResp` trait.
+/// Add `__bytes__`, `__str__`, `__repr__`, `to_json`, `from_json`, `from_bytes` and `__richcmp__` using the `CommonMethodsRpcResp` trait.
 #[proc_macro_attribute]
 pub fn common_methods_rpc_resp(_: TokenStream, item: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(item as ItemImpl);

--- a/crates/primitives/src/rent.rs
+++ b/crates/primitives/src/rent.rs
@@ -8,7 +8,7 @@ use solana_rent::{
 use solders_traits_core::transaction_status_boilerplate;
 
 /// Configuration of network rent.
-#[pyclass(module = "solders.account", subclass)]
+#[pyclass(module = "solders.rent", subclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default, From, Into)]
 pub struct Rent(pub RentOriginal);
 

--- a/crates/traits-core/src/lib.rs
+++ b/crates/traits-core/src/lib.rs
@@ -267,3 +267,23 @@ macro_rules! transaction_status_boilerplate {
         $crate::common_methods_default!($name);
     };
 }
+
+/// Like [`transaction_status_boilerplate`] but serializes bytes via CBOR.
+///
+/// Use this for types that can't round-trip through bincode (e.g. those with
+/// `#[serde(flatten)]` or `#[serde(skip_serializing_if)]` fields, which bincode
+/// can't represent positionally).
+#[macro_export]
+macro_rules! transaction_status_boilerplate_cbor {
+    ($name:ident) => {
+        impl $crate::RichcmpEqualityOnly for $name {}
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{:?}", self)
+            }
+        }
+        $crate::pybytes_general_via_cbor!($name);
+        $crate::py_from_bytes_general_via_cbor!($name);
+        $crate::common_methods_default!($name);
+    };
+}

--- a/crates/transaction-status/src/lib.rs
+++ b/crates/transaction-status/src/lib.rs
@@ -10,7 +10,7 @@ use solders_signature::Signature;
 use solders_traits_core::{
     common_methods_default, handle_py_value_err, py_from_bytes_general_via_bincode,
     pybytes_general_via_bincode, richcmp_type_error, transaction_status_boilerplate,
-    RichcmpEqualityOnly,
+    transaction_status_boilerplate_cbor, RichcmpEqualityOnly,
 };
 use solders_transaction_confirmation_status::TransactionConfirmationStatus;
 use solders_transaction_error::{
@@ -1075,7 +1075,7 @@ pub struct EncodedConfirmedTransactionWithStatusMeta {
     pub block_time: Option<i64>,
 }
 
-transaction_status_boilerplate!(EncodedConfirmedTransactionWithStatusMeta);
+transaction_status_boilerplate_cbor!(EncodedConfirmedTransactionWithStatusMeta);
 
 #[richcmp_eq_only]
 #[common_methods]

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -11,6 +11,7 @@ from solders.message import Message
 from solders.pubkey import Pubkey
 from solders.rent import Rent
 from solders.rpc.requests import GetBalance
+from solders.rpc.responses import GetBalanceResp, GetBlockHeightResp, RpcResponseContext
 from solders.signature import Signature
 
 # A spread across the macro families: byte wrappers and complex types
@@ -35,6 +36,21 @@ def test_pickle(original: Any) -> None:
 
 @pytest.mark.parametrize("original", objects)
 def test_deepcopy(original: Any) -> None:
+    copied = copy.deepcopy(original)
+    assert copied == original
+    assert copied is not original
+
+
+# RPC response types support deepcopy (via clone) but not pickle, since their
+# bincode round-trip is broken by skip_serializing_if.
+response_objects: List[Any] = [
+    GetBlockHeightResp(1234),
+    GetBalanceResp(5, RpcResponseContext(slot=1)),
+]
+
+
+@pytest.mark.parametrize("original", response_objects)
+def test_deepcopy_responses(original: Any) -> None:
     copied = copy.deepcopy(original)
     assert copied == original
     assert copied is not original

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,40 @@
+import copy
+import pickle
+from typing import Any, List
+
+import pytest
+from solders.account import Account
+from solders.hash import Hash
+from solders.instruction import Instruction
+from solders.keypair import Keypair
+from solders.message import Message
+from solders.pubkey import Pubkey
+from solders.rent import Rent
+from solders.rpc.requests import GetBalance
+from solders.signature import Signature
+
+# A spread across the macro families: byte wrappers and complex types
+# (common_methods), a primitive, and a request (common_methods_ser_only).
+objects: List[Any] = [
+    Pubkey.new_unique(),
+    Hash.default(),
+    Signature.default(),
+    Keypair(),
+    Account.default(),
+    Message.default(),
+    Instruction(Pubkey.default(), b"data", []),
+    Rent.default(),
+    GetBalance(Pubkey.default()),
+]
+
+
+@pytest.mark.parametrize("original", objects)
+def test_pickle(original: Any) -> None:
+    assert pickle.loads(pickle.dumps(original)) == original
+
+
+@pytest.mark.parametrize("original", objects)
+def test_deepcopy(original: Any) -> None:
+    copied = copy.deepcopy(original)
+    assert copied == original
+    assert copied is not original

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -11,11 +11,30 @@ from solders.message import Message
 from solders.pubkey import Pubkey
 from solders.rent import Rent
 from solders.rpc.requests import GetBalance
-from solders.rpc.responses import GetBalanceResp, GetBlockHeightResp, RpcResponseContext
+from solders.rpc.responses import (
+    GetBalanceResp,
+    GetBlockHeightResp,
+    GetTransactionResp,
+    RpcResponseContext,
+)
 from solders.signature import Signature
+from solders.transaction_status import EncodedConfirmedTransactionWithStatusMeta
+
+_TX_RESP = GetTransactionResp.from_json(
+    '{"jsonrpc":"2.0","result":{"slot":430,"transaction":{"message":{"accountKeys":'
+    '["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe"],"header":'
+    '{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":0,'
+    '"numRequiredSignatures":1},"instructions":[],"recentBlockhash":'
+    '"11111111111111111111111111111111"},"signatures":["5Ve"]},"meta":null,'
+    '"blockTime":null},"id":1}'
+)
+assert isinstance(_TX_RESP, GetTransactionResp)
+_ENCODED_TX_RESP = _TX_RESP.value
+assert isinstance(_ENCODED_TX_RESP, EncodedConfirmedTransactionWithStatusMeta)
 
 # A spread across the macro families: byte wrappers and complex types
-# (common_methods), a primitive, and a request (common_methods_ser_only).
+# (common_methods), a primitive, a request (common_methods_ser_only), and a
+# type with a #[serde(flatten)] field (serialized via CBOR, not bincode).
 objects: List[Any] = [
     Pubkey.new_unique(),
     Hash.default(),
@@ -26,6 +45,7 @@ objects: List[Any] = [
     Instruction(Pubkey.default(), b"data", []),
     Rent.default(),
     GetBalance(Pubkey.default()),
+    _ENCODED_TX_RESP,
 ]
 
 


### PR DESCRIPTION
Restores pickle and `copy.deepcopy` support, removed in 0.25, via a single macro-level mechanism rather than per-type methods. Supersedes #165 (pickle for 3 types) and #166 (deepcopy via clone).

## common_methods family

`add_core_methods` now generates a `__reduce__` that reconstructs via `from_bytes(bytes(self))`, relying only on the Python-level `__bytes__`/`from_bytes` each type already has. This gives **both pickle and deepcopy** to every type using `common_methods`, `common_methods_core`, and `common_methods_ser_only` — Pubkey, Hash, Signature, Keypair, Account, Message, Instruction, Transaction, request types, primitives, etc.

Also fixes `Rent`, which declared `module = "solders.account"` but is exported from `solders.rent`; the mismatch broke pickle-by-reference. It was the only such mislabel.

## RPC response types

Response types can't use the `from_bytes`-based `__reduce__`: their bincode round-trip is broken by `#[serde(skip_serializing_if = "Option::is_none")]` on `RpcResponseContext.api_version`. With `api_version = None` the field is omitted on serialize, but bincode deserialize still expects it positionally and misreads the next field. So `common_methods_rpc_resp` instead gets a clone-based `__deepcopy__`, which sidesteps serialization. These types support `copy.deepcopy` but not pickle (pickle would need the serialization fixed separately, e.g. an `is_human_readable`-aware `Serialize` for `RpcResponseContext`).

## Tests

`tests/test_pickle.py` covers pickle + deepcopy across the macro families, plus deepcopy for response types.

Verified: pytest, mypy, ruff, `cargo clippy` and `--no-default-features` under `-D warnings`.
