### PR TITLE
Upgrade pyo3 and pythonize to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,15 +1444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,15 +1690,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "merlin"
@@ -2040,35 +2022,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2076,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2088,22 +2067,21 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.118",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e06e4cff9be2bbf2bddf28a486ae619172ea57e79787f856572878c62dcfe2"
+checksum = "6ec376e1216e0c929a74964ce2020012a1a39f32d80e78aa688721219ea7fb89"
 dependencies = [
  "pyo3",
  "serde",
@@ -5108,12 +5086,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ derive_more = "0.99.17"
 five8 = "0.2.1"
 litesvm = "0.13"
 log = "0.4"
-pyo3 = { version = "0.26", default-features = false }
-pythonize = "0.26"
-serde = "^1.0.188"
+pyo3 = { version = "0.29", default-features = false }
+pythonize = "0.29"
+serde = { version = "^1.0.188", features = ["derive"] }
 serde_bytes = "0.11.12"
 serde_cbor = "^0.11.2"
 serde_json = "^1.0.106"

--- a/crates/account-decoder/src/lib.rs
+++ b/crates/account-decoder/src/lib.rs
@@ -21,7 +21,7 @@ use solders_macros::{common_methods, enum_original_mapping, richcmp_eq_only};
 ///     offset (int): Skip this many bytes at the beginning of the data.
 ///     length (int): Return only this many bytes.
 ///
-#[pyclass(module = "solders.account_decoder")]
+#[pyclass(from_py_object, module = "solders.account_decoder")]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash, From, Into)]
 pub struct UiDataSliceConfig(UiDataSliceConfigOriginal);
 
@@ -51,7 +51,7 @@ impl UiDataSliceConfig {
 impl RichcmpEqualityOnly for UiDataSliceConfig {}
 
 /// Encoding options for account data.
-#[pyclass(module = "solders.account_decoder", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.account_decoder", eq, eq_int)]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 #[enum_original_mapping(UiAccountEncodingOriginal)]
@@ -65,7 +65,7 @@ pub enum UiAccountEncoding {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, From, Into)]
-#[pyclass(module = "solders.account_decoder")]
+#[pyclass(from_py_object, module = "solders.account_decoder")]
 pub struct ParsedAccount(pub ParsedAccountOriginal);
 
 impl RichcmpEqualityOnly for ParsedAccount {}
@@ -110,7 +110,7 @@ impl ParsedAccount {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, From, Into)]
-#[pyclass(module = "solders.account_decoder")]
+#[pyclass(from_py_object, module = "solders.account_decoder")]
 pub struct UiTokenAmount(UiTokenAmountOriginal);
 
 impl RichcmpEqualityOnly for UiTokenAmount {}

--- a/crates/account/src/lib.rs
+++ b/crates/account/src/lib.rs
@@ -28,7 +28,7 @@ use solders_account_decoder::ParsedAccount;
 #[serde_as]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Default, Debug)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.account", subclass)]
+#[pyclass(from_py_object, module = "solders.account", subclass)]
 pub struct Account {
     /// lamports in the account
     #[pyo3(get)]
@@ -173,7 +173,7 @@ impl From<Account> for UiAccount {
 #[serde_as]
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.account", subclass)]
+#[pyclass(from_py_object, module = "solders.account", subclass)]
 pub struct AccountJSON {
     /// int: Lamports in the account.
     #[pyo3(get)]

--- a/crates/address-lookup-table-account/src/lib.rs
+++ b/crates/address-lookup-table-account/src/lib.rs
@@ -41,7 +41,7 @@ struct AddressLookupTableAccountOriginalDef {
 
 /// The definition of address lookup table accounts as used by ``MessageV0``.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.address_lookup_table_account", subclass)]
+#[pyclass(from_py_object, module = "solders.address_lookup_table_account", subclass)]
 pub struct AddressLookupTableAccount(
     #[serde(with = "AddressLookupTableAccountOriginalDef")] AddressLookupTableAccountOriginal,
 );
@@ -78,7 +78,7 @@ impl AddressLookupTableAccount {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.address_lookup_table_account", subclass)]
+#[pyclass(from_py_object, module = "solders.address_lookup_table_account", subclass)]
 pub struct LookupTableStatusDeactivating(pub usize);
 impl_defaults!(LookupTableStatusDeactivating);
 
@@ -103,7 +103,7 @@ pub enum LookupTableStatusTagged {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-#[pyclass(module = "solders.address_lookup_table_account", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.address_lookup_table_account", eq, eq_int)]
 pub enum LookupTableStatusFieldless {
     Activated,
     Deactivated,
@@ -152,7 +152,7 @@ impl From<LookupTableStatusType> for LookupTableStatusOriginal {
     }
 }
 
-#[pyclass(module = "solders.address_lookup_table_account", subclass)]
+#[pyclass(from_py_object, module = "solders.address_lookup_table_account", subclass)]
 #[derive(Debug, PartialEq, Eq, From, Into, Serialize, Deserialize)]
 pub struct SlotHashes(SlotHashesOriginal);
 
@@ -187,7 +187,7 @@ impl SlotHashes {
     }
 }
 
-#[pyclass(module = "solders.address_lookup_table_account", subclass)]
+#[pyclass(from_py_object, module = "solders.address_lookup_table_account", subclass)]
 #[derive(Clone, Debug, PartialEq, Eq, From, Into, Serialize, Deserialize)]
 pub struct LookupTableMeta(LookupTableMetaOriginal);
 
@@ -257,7 +257,7 @@ pub struct AddressLookupTableOriginalDef<'a> {
     addresses: Cow<'a, [PubkeyOriginal]>,
 }
 
-#[pyclass(module = "solders.address_lookup_table_account", subclass)]
+#[pyclass(from_py_object, module = "solders.address_lookup_table_account", subclass)]
 #[derive(Clone, Debug, PartialEq, From, Into, Serialize, Deserialize)]
 pub struct AddressLookupTable(
     #[serde(with = "AddressLookupTableOriginalDef")] AddressLookupTableOriginal<'static>,

--- a/crates/commitment-config/src/lib.rs
+++ b/crates/commitment-config/src/lib.rs
@@ -10,7 +10,7 @@ use solana_commitment_config::{
 use solders_traits::handle_py_err;
 
 /// RPC request `commitment <https://docs.solana.com/developing/clients/jsonrpc-api#configuring-state-commitment>`_ options.
-#[pyclass(module = "solders.commitment_config", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.commitment_config", eq, eq_int)]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum CommitmentLevel {
     /// The highest slot of the heaviest fork processed by the node. Ledger state at this slot is
@@ -76,7 +76,7 @@ impl From<CommitmentLevel> for CommitmentLevelOriginal {
 ///
 /// Args:
 ///     commitment (CommitmentLevel): Bank state to query.
-#[pyclass(module = "solders.commitment_config", subclass)]
+#[pyclass(from_py_object, module = "solders.commitment_config", subclass)]
 #[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq, Hash, From, Into)]
 pub struct CommitmentConfig(CommitmentConfigOriginal);
 

--- a/crates/compute-budget/src/lib.rs
+++ b/crates/compute-budget/src/lib.rs
@@ -33,7 +33,7 @@ pub fn set_compute_unit_price(micro_lamports: u64) -> Instruction {
     ComputeBudgetInstruction::set_compute_unit_price(micro_lamports).into()
 }
 
-#[pyclass(module = "solders.compute_budget", subclass)]
+#[pyclass(from_py_object, module = "solders.compute_budget", subclass)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ComputeBudget(pub ComputeBudgetOriginal);
 

--- a/crates/dict-derive/src/from.rs
+++ b/crates/dict-derive/src/from.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote, quote_spanned};
 use syn::{parse_quote, spanned::Spanned, Data, DeriveInput, Field, Ident};
 
 fn is_option(ty: &syn::Type) -> bool {
@@ -32,7 +32,7 @@ fn map_extraction(field: Field) -> TokenStream {
     };
 
     quote_spanned! {ident.span()=>
-        #ident: #function(dict, #name)?
+        #ident: #function(&dict, #name)?
     }
 }
 
@@ -42,13 +42,13 @@ fn extraction_functions() -> TokenStream {
             PyErr::new::<PyTypeError, _>(format!("Unable to convert key: {}. Error: {}", name, e))
         }
 
-        fn extract_required<'a, T>(dict: &Bound<'a, PyDict>, name: &str) -> PyResult<T>
+        fn extract_required<'py, T>(dict: &Bound<'py, PyDict>, name: &str) -> PyResult<T>
         where
-            T: FromPyObject<'a>,
+            T: for<'a> FromPyObject<'a, 'py>,
         {
             match PyDictMethods::get_item(dict, name)? {
-                Some(v) => FromPyObject::extract_bound(&v)
-                    .map_err(|err| map_exception(name, err)),
+                Some(v) => PyAnyMethods::extract::<T>(&v)
+                    .map_err(|err| map_exception(name, err.into())),
                 None => Err(PyErr::new::<PyValueError, _>(format!(
                     "Missing required key: {}",
                     name
@@ -56,13 +56,13 @@ fn extraction_functions() -> TokenStream {
             }
         }
 
-        fn extract_optional<'a, T>(dict: &Bound<'a, PyDict>, name: &str) -> PyResult<std::option::Option<T>>
+        fn extract_optional<'py, T>(dict: &Bound<'py, PyDict>, name: &str) -> PyResult<std::option::Option<T>>
         where
-            T: FromPyObject<'a>,
+            std::option::Option<T>: for<'a> FromPyObject<'a, 'py>,
         {
             match PyDictMethods::get_item(dict, name)? {
-                Some(v) => FromPyObject::extract_bound(&v)
-                    .map_err(|err| map_exception(name, err)),
+                Some(v) => PyAnyMethods::extract::<std::option::Option<T>>(&v)
+                    .map_err(|err| map_exception(name, err.into())),
                 None => Ok(None),
             }
         }
@@ -87,23 +87,15 @@ pub fn from_impl(ast: DeriveInput) -> TokenStream {
     let name = ast.ident;
     let mut impl_generics = ast.generics.clone();
 
-    let lifetimes_count = impl_generics.lifetimes().count();
-
-    if lifetimes_count > 1 {
+    if impl_generics.lifetimes().count() > 0 {
         return syn::Error::new(
             impl_generics.span(),
-            "Deriving structs with more than one lifetime is not supported",
+            "Deriving structs with lifetimes is not supported",
         )
         .to_compile_error();
-    } else if lifetimes_count == 0 {
-        impl_generics.params.push(parse_quote!('source));
-    };
-
-    let lifetime = impl_generics
-        .lifetimes()
-        .next()
-        .map(|lt| lt.lifetime.to_token_stream())
-        .unwrap();
+    }
+    // The `'py` (Python) lifetime; the input lifetime is elided.
+    impl_generics.params.push(parse_quote!('py));
 
     let (_, ty_generics, where_clause) = ast.generics.split_for_impl();
     let (impl_generics, _, _) = impl_generics.split_for_impl();
@@ -111,15 +103,17 @@ pub fn from_impl(ast: DeriveInput) -> TokenStream {
     let functions = extraction_functions();
 
     quote! {
-        impl #impl_generics ::pyo3::FromPyObject<#lifetime> for #name #ty_generics #where_clause {
-            fn extract_bound(
-                obj: &::pyo3::prelude::Bound<#lifetime, ::pyo3::types::PyAny>,
+        impl #impl_generics ::pyo3::FromPyObject<'_, 'py> for #name #ty_generics #where_clause {
+            type Error = ::pyo3::PyErr;
+
+            fn extract(
+                obj: ::pyo3::Borrowed<'_, 'py, ::pyo3::types::PyAny>,
             ) -> ::pyo3::PyResult<Self> {
                 use ::pyo3::{FromPyObject, PyErr, PyResult};
                 use ::pyo3::exceptions::{PyTypeError, PyValueError};
                 use ::pyo3::prelude::Bound;
                 use ::pyo3::types::{PyAnyMethods, PyDict, PyDictMethods};
-                let dict = obj.downcast::<PyDict>().map_err(|_| {
+                let dict = obj.cast::<PyDict>().map_err(|_| {
                     PyErr::new::<PyTypeError, _>("Invalid type to convert, expected dict")
                 })?;
 

--- a/crates/epoch-info/src/lib.rs
+++ b/crates/epoch-info/src/lib.rs
@@ -19,7 +19,7 @@ use solders_traits_core::{
 ///     block_height (int): The current block height.
 ///     transaction_count (Optional[int]): Total number of transactions processed without error since genesis
 ///
-#[pyclass(module = "solders.epoch_info", subclass)]
+#[pyclass(from_py_object, module = "solders.epoch_info", subclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, From, Into)]
 pub struct EpochInfo(EpochInfoOriginal);
 

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -13,7 +13,7 @@ use solders_traits_core::{
     RichcmpFull,
 };
 
-#[pyclass(module = "solders.hash", subclass)]
+#[pyclass(from_py_object, module = "solders.hash", subclass)]
 /// A SHA-256 hash, most commonly used for blockhashes.
 ///
 /// Args:

--- a/crates/instruction/src/lib.rs
+++ b/crates/instruction/src/lib.rs
@@ -46,7 +46,7 @@ use solders_traits_core::{
 ///     >>> accs = [AccountMeta(from_pubkey, is_signer=True, is_writable=True), AccountMeta(to_pubkey, is_signer=True, is_writable=True)]
 ///     >>> instruction = Instruction(program_id, instruction_data, accs)
 ///
-#[pyclass(module = "solders.instruction", subclass)]
+#[pyclass(from_py_object, module = "solders.instruction", subclass)]
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, From, Into)]
 pub struct AccountMeta(AccountMetaOriginal);
 #[pyhash]
@@ -111,7 +111,7 @@ impl std::hash::Hash for AccountMeta {
     }
 }
 
-#[pyclass(module = "solders.instruction", subclass)]
+#[pyclass(from_py_object, module = "solders.instruction", subclass)]
 /// A directive for a single invocation of a Solana program.
 ///
 /// An instruction specifies which program it is calling, which accounts it may
@@ -269,7 +269,7 @@ impl AsRef<InstructionOriginal> for Instruction {
 ///     accounts (bytes): Ordered indices into the transaction keys array indicating
 ///         which accounts to pass to the program.
 ///
-#[pyclass(module = "solders.instruction", subclass)]
+#[pyclass(from_py_object, module = "solders.instruction", subclass)]
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, From, Into)]
 pub struct CompiledInstruction(pub CompiledInstructionOriginal);
 

--- a/crates/keypair/src/lib.rs
+++ b/crates/keypair/src/lib.rs
@@ -43,7 +43,7 @@ mod keypair_serde {
     }
 }
 
-#[pyclass(module = "solders.keypair", subclass)]
+#[pyclass(from_py_object, module = "solders.keypair", subclass)]
 #[derive(PartialEq, Debug, Serialize, Deserialize, From, Into)]
 /// A vanilla Ed25519 key pair.
 ///

--- a/crates/keypair/src/null_signer.rs
+++ b/crates/keypair/src/null_signer.rs
@@ -36,7 +36,7 @@ mod null_signer_serde {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.null_signer", subclass)]
+#[pyclass(from_py_object, module = "solders.null_signer", subclass)]
 /// A signer implementation that always produces :meth:`solders.signature.Signature.default()`.
 /// Used as a placeholder for absentee signers whose 'Pubkey` is required to construct
 /// the transaction.

--- a/crates/keypair/src/presigner.rs
+++ b/crates/keypair/src/presigner.rs
@@ -11,7 +11,7 @@ use solders_traits::{
 use solders_traits_core::{impl_display, PyHash};
 
 #[derive(Clone, Debug, Default, PartialEq)]
-#[pyclass(module = "solders.presigner", subclass)]
+#[pyclass(from_py_object, module = "solders.presigner", subclass)]
 /// A signer that represents a :class:`~solders.signature.Signature` that has been
 /// constructed externally. Performs a signature verification against the
 /// expected message upon ``sign()`` requests to affirm its relationship to

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -31,7 +31,7 @@ use {
 pub mod transaction_metadata;
 
 #[derive(Debug, Clone, PartialEq)]
-#[pyclass(module = "solders.litesvm", subclass)]
+#[pyclass(from_py_object, module = "solders.litesvm", subclass)]
 pub struct FeatureSet(pub(crate) FeatureSetOriginal);
 
 impl RichcmpEqualityOnly for FeatureSet {}

--- a/crates/litesvm/src/transaction_metadata.rs
+++ b/crates/litesvm/src/transaction_metadata.rs
@@ -20,7 +20,7 @@ use {
 
 /// A compiled instruction that was invoked during a
 /// transaction instruction.
-#[pyclass(module = "solders.transaction_metadata", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_metadata", subclass)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct InnerInstruction(InnerInstructionOriginal);
 
@@ -46,7 +46,7 @@ impl InnerInstruction {
 }
 
 /// Information about sent transactions.
-#[pyclass(module = "solders.transaction_metadata", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_metadata", subclass)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct TransactionMetadata(pub(crate) TransactionMetadataOriginal);
 
@@ -113,7 +113,7 @@ impl TransactionMetadata {
 }
 
 /// Information about failed transactions.
-#[pyclass(module = "solders.transaction_metadata", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_metadata", subclass)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct FailedTransactionMetadata(pub(crate) FailedTransactionMetadataOriginal);
 
@@ -139,7 +139,7 @@ impl FailedTransactionMetadata {
 }
 
 /// Information about simulated transactions.
-#[pyclass(module = "solders.transaction_metadata", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_metadata", subclass)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimulatedTransactionInfo(pub(crate) SimulatedTransactionInfoOriginal);
 

--- a/crates/message/src/lib.rs
+++ b/crates/message/src/lib.rs
@@ -28,7 +28,7 @@ use solders_hash::Hash as SolderHash;
 use solders_instruction::{convert_instructions, CompiledInstruction, Instruction};
 use solders_pubkey::{convert_optional_pubkey, Pubkey};
 
-#[pyclass(module = "solders.message", subclass)]
+#[pyclass(from_py_object, module = "solders.message", subclass)]
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone, From, Into)]
 /// Describes the organization of a :class:`Message`'s account keys.
 ///
@@ -135,7 +135,7 @@ impl_display!(MessageHeader);
 py_from_bytes_general_via_bincode!(MessageHeader);
 solders_traits_core::common_methods_default!(MessageHeader);
 
-#[pyclass(module = "solders.message", subclass)]
+#[pyclass(from_py_object, module = "solders.message", subclass)]
 #[derive(PartialEq, Eq, Debug, Clone, Default, Serialize, Deserialize, From, Into)]
 /// A Solana transaction message.
 ///
@@ -517,7 +517,7 @@ impl From<&Message> for MessageOriginal {
     }
 }
 
-#[pyclass(module = "solders.message", subclass)]
+#[pyclass(from_py_object, module = "solders.message", subclass)]
 #[derive(PartialEq, Eq, Debug, Clone, Default, Serialize, Deserialize, From, Into)]
 /// Address table lookups describe an on-chain address lookup table to use
 /// for loading more readonly and writable accounts in a single tx.
@@ -575,7 +575,7 @@ create_exception!(
     "Raised when an error is encountered in compiling a message."
 );
 
-#[pyclass(module = "solders.message", subclass)]
+#[pyclass(from_py_object, module = "solders.message", subclass)]
 #[derive(PartialEq, Eq, Debug, Clone, Default, Serialize, Deserialize, From, Into)]
 /// A Solana transaction message (v0).
 ///

--- a/crates/primitives/src/clock.rs
+++ b/crates/primitives/src/clock.rs
@@ -18,7 +18,7 @@ use solders_traits_core::transaction_status_boilerplate;
 /// A representation of network time.
 ///
 /// All members of ``Clock`` start from 0 upon network boot.
-#[pyclass(module = "solders.clock", subclass)]
+#[pyclass(from_py_object, module = "solders.clock", subclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, From, Into)]
 pub struct Clock(pub ClockOriginal);
 

--- a/crates/primitives/src/epoch_rewards.rs
+++ b/crates/primitives/src/epoch_rewards.rs
@@ -8,7 +8,7 @@ use {
 
 /// A type to hold data for the EpochRewards sysvar.
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-#[pyclass(module = "solders.epoch_rewards", subclass)]
+#[pyclass(from_py_object, module = "solders.epoch_rewards", subclass)]
 pub struct EpochRewards(pub EpochRewardsOriginal);
 
 transaction_status_boilerplate!(EpochRewards);

--- a/crates/primitives/src/epoch_schedule.rs
+++ b/crates/primitives/src/epoch_schedule.rs
@@ -17,7 +17,7 @@ use solders_traits_core::{
 /// Args:
 ///     slots_per_epoch (int): The maximum number of slots in each epoch.
 ///
-#[pyclass(module = "solders.epoch_schedule", subclass)]
+#[pyclass(from_py_object, module = "solders.epoch_schedule", subclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, From, Into)]
 pub struct EpochSchedule(pub EpochScheduleOriginal);
 

--- a/crates/primitives/src/rent.rs
+++ b/crates/primitives/src/rent.rs
@@ -11,7 +11,7 @@ use solana_rent::{
 use solders_traits_core::transaction_status_boilerplate;
 
 /// Configuration of network rent.
-#[pyclass(module = "solders.rent", subclass)]
+#[pyclass(from_py_object, module = "solders.rent", subclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default, From, Into)]
 pub struct Rent(pub RentOriginal);
 

--- a/crates/primitives/src/slot_history.rs
+++ b/crates/primitives/src/slot_history.rs
@@ -19,7 +19,7 @@ pub enum SlotHistoryCheck {
 
 /// A bitvector indicating which slots are present in the past epoch.
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-#[pyclass(module = "solders.slot_history", subclass)]
+#[pyclass(from_py_object, module = "solders.slot_history", subclass)]
 pub struct SlotHistory(pub SlotHistoryOriginal);
 
 transaction_status_boilerplate!(SlotHistory);

--- a/crates/primitives/src/stake_history.rs
+++ b/crates/primitives/src/stake_history.rs
@@ -8,7 +8,7 @@ use {
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-#[pyclass(module = "solders.stake_history", subclass)]
+#[pyclass(from_py_object, module = "solders.stake_history", subclass)]
 pub struct StakeHistoryEntry(pub(crate) StakeHistoryEntryOriginal);
 
 transaction_status_boilerplate!(StakeHistoryEntry);
@@ -82,7 +82,7 @@ impl StakeHistoryEntry {
 
 /// A type to hold data for the StakeHistory sysvar.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-#[pyclass(module = "solders.stake_history", subclass)]
+#[pyclass(from_py_object, module = "solders.stake_history", subclass)]
 pub struct StakeHistory(pub StakeHistoryOriginal);
 
 transaction_status_boilerplate!(StakeHistory);

--- a/crates/pubkey/src/lib.rs
+++ b/crates/pubkey/src/lib.rs
@@ -24,7 +24,7 @@ use solders_traits_core::{
 ///     >>> bytes(pubkey).hex()
 ///     '0101010101010101010101010101010101010101010101010101010101010101'
 ///
-#[pyclass(module = "solders.pubkey", subclass)]
+#[pyclass(from_py_object, module = "solders.pubkey", subclass)]
 #[derive(
     Eq,
     PartialEq,

--- a/crates/rpc-common/src/lib.rs
+++ b/crates/rpc-common/src/lib.rs
@@ -19,7 +19,7 @@ use solders_transaction_status::{
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcSimulateTransactionResult(RpcSimulateTransactionResultOriginal);
 
 response_data_boilerplate!(RpcSimulateTransactionResult);

--- a/crates/rpc-config-macros/src/lib.rs
+++ b/crates/rpc-config-macros/src/lib.rs
@@ -24,7 +24,7 @@ macro_rules! pyclass_boilerplate {
     ($(#[$attr:meta])* => $name:ident) => {
         $(#[$attr])*
         #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-        #[pyclass(module = "solders.rpc.config", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
         pub struct $name(rpc_config::$name);
         rpc_config_impls!($name);
     };
@@ -35,7 +35,7 @@ macro_rules! pyclass_boilerplate_with_default {
     ($(#[$attr:meta])* => $name:ident) => {
         $(#[$attr])*
         #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-        #[pyclass(module = "solders.rpc.config", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
         pub struct $name(rpc_config::$name);
         $crate::rpc_config_impls!($name);
     };

--- a/crates/rpc-config-no-filter/src/lib.rs
+++ b/crates/rpc-config-no-filter/src/lib.rs
@@ -96,7 +96,7 @@ impl RpcBlockProductionConfigRange {
 ///     commitment (Optional[CommitmentLevel]): Bank state to query.
 ///
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[pyclass(module = "solders.rpc.config", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
 pub struct RpcBlockProductionConfig(rpc_config::RpcBlockProductionConfig);
 
 impl PartialEq for RpcBlockProductionConfig {
@@ -225,7 +225,7 @@ impl RpcGetVoteAccountsConfig {
 }
 
 /// Filter for ``getLargestAccounts``.
-#[pyclass(module = "solders.rpc.config", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.rpc.config", eq, eq_int)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RpcLargestAccountsFilter {

--- a/crates/rpc-config-no-rpc-api/src/lib.rs
+++ b/crates/rpc-config-no-rpc-api/src/lib.rs
@@ -9,7 +9,7 @@ use solders_traits_core::RichcmpEqualityOnly;
 /// Fieldless filters for ``logsSubscribe``.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.rpc.config", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.rpc.config", eq, eq_int)]
 pub enum RpcTransactionLogsFilter {
     All,
     AllWithVotes,
@@ -21,7 +21,7 @@ pub enum RpcTransactionLogsFilter {
 ///     pubkey (Pubkey): Subscribe to all transactions that mention the provided Pubkey.
 ///
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[pyclass(module = "solders.rpc.config", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
 pub struct RpcTransactionLogsFilterMentions(pub Vec<String>);
 
 #[richcmp_eq_only]
@@ -50,7 +50,7 @@ impl RichcmpEqualityOnly for RpcTransactionLogsFilterMentions {}
 ///     mint (Pubkey):  Pubkey of the specific token Mint to limit accounts to.
 ///
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[pyclass(module = "solders.rpc.config", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
 pub struct RpcTokenAccountsFilterMint(pub Pubkey);
 
 #[richcmp_eq_only]
@@ -79,7 +79,7 @@ impl RichcmpEqualityOnly for RpcTokenAccountsFilterMint {}
 ///     program_id (Pubkey):   Pubkey of the Token program that owns the accounts.
 ///
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[pyclass(module = "solders.rpc.config", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
 pub struct RpcTokenAccountsFilterProgramId(pub Pubkey);
 
 #[richcmp_eq_only]
@@ -105,7 +105,7 @@ impl RichcmpEqualityOnly for RpcTokenAccountsFilterProgramId {}
 /// Filter for ``blockSubscribe``.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.rpc.config", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.rpc.config", eq, eq_int)]
 pub enum RpcBlockSubscribeFilter {
     All,
 }
@@ -116,7 +116,7 @@ pub enum RpcBlockSubscribeFilter {
 ///     pubkey (Pubkey): Return only transactions that mention the provided pubkey.
 ///
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[pyclass(module = "solders.rpc.config", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.config", subclass)]
 pub struct RpcBlockSubscribeFilterMentions(pub String);
 
 #[richcmp_eq_only]

--- a/crates/rpc-errors-common/src/lib.rs
+++ b/crates/rpc-errors-common/src/lib.rs
@@ -2,7 +2,7 @@
 macro_rules! error_message {
     ($name:ident) => {
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-        #[pyclass(module = "solders.rpc.errors", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
         #[serde(rename_all = "camelCase")]
         pub struct $name {
             #[pyo3(get)]
@@ -23,7 +23,7 @@ macro_rules! error_message {
     };
     ($name:ident, $data_type:ty) => {
         #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, From, Into)]
-        #[pyclass(module = "solders.rpc.errors", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
         #[serde(rename_all = "camelCase")]
         pub struct $name {
             #[pyo3(get)]

--- a/crates/rpc-errors-no-tx-status/src/lib.rs
+++ b/crates/rpc-errors-no-tx-status/src/lib.rs
@@ -8,7 +8,7 @@ use solders_transaction_error::TransactionErrorType;
 type Slot = u64;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockCleanedUp {
     #[pyo3(get)]
@@ -32,7 +32,7 @@ impl BlockCleanedUp {
 error_message!(BlockCleanedUpMessage);
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 pub enum RpcCustomErrorFieldless {
     TransactionSignatureVerificationFailure,
     NoSnapshot,
@@ -41,7 +41,7 @@ pub enum RpcCustomErrorFieldless {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct BlockNotAvailable {
     #[pyo3(get)]
     slot: Slot,
@@ -62,7 +62,7 @@ impl BlockNotAvailable {
 error_message!(BlockNotAvailableMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeUnhealthy {
     #[pyo3(get)]
@@ -85,7 +85,7 @@ impl NodeUnhealthy {
 error_message!(NodeUnhealthyMessage, NodeUnhealthy);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct TransactionPrecompileVerificationFailure(TransactionErrorType);
 
 transaction_status_boilerplate!(TransactionPrecompileVerificationFailure);
@@ -108,7 +108,7 @@ impl TransactionPrecompileVerificationFailure {
 error_message!(TransactionPrecompileVerificationFailureMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct SlotSkipped {
     #[pyo3(get)]
     slot: Slot,
@@ -129,7 +129,7 @@ impl SlotSkipped {
 error_message!(SlotSkippedMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct LongTermStorageSlotSkipped {
     #[pyo3(get)]
     slot: Slot,
@@ -150,7 +150,7 @@ impl LongTermStorageSlotSkipped {
 error_message!(LongTermStorageSlotSkippedMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyExcludedFromSecondaryIndex {
     #[pyo3(get)]
@@ -172,7 +172,7 @@ impl KeyExcludedFromSecondaryIndex {
 error_message!(KeyExcludedFromSecondaryIndexMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct ScanError {
     #[pyo3(get)]
     message: String,
@@ -193,7 +193,7 @@ impl ScanError {
 error_message!(ScanErrorMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct BlockStatusNotAvailableYet {
     #[pyo3(get)]
     slot: Slot,
@@ -214,7 +214,7 @@ impl BlockStatusNotAvailableYet {
 error_message!(BlockStatusNotAvailableYetMessage);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 #[serde(rename_all = "camelCase")]
 pub struct MinContextSlotNotReached {
     #[pyo3(get)]
@@ -236,7 +236,7 @@ impl MinContextSlotNotReached {
 error_message!(MinContextSlotNotReachedMessage, MinContextSlotNotReached);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct UnsupportedTransactionVersion(pub u8);
 
 transaction_status_boilerplate!(UnsupportedTransactionVersion);

--- a/crates/rpc-errors-tx-status/src/lib.rs
+++ b/crates/rpc-errors-tx-status/src/lib.rs
@@ -7,7 +7,7 @@ use solders_rpc_errors_common::error_message;
 use solders_traits_core::transaction_status_boilerplate;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.errors", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.errors", subclass)]
 pub struct SendTransactionPreflightFailure {
     #[pyo3(get)]
     message: String,

--- a/crates/rpc-filter/src/lib.rs
+++ b/crates/rpc-filter/src/lib.rs
@@ -46,7 +46,7 @@ impl From<MemcmpEncodedBytesOriginal> for MemcmpEncodedBytes {
 ///     bytes_ (str | Sequnce[int]): Bytes, encoded with specified encoding, or default Binary
 ///
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.rpc.filter", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.filter", subclass)]
 pub struct Memcmp(MemcmpOriginal);
 
 pybytes_general_via_bincode!(Memcmp);
@@ -73,7 +73,7 @@ impl RichcmpEqualityOnly for Memcmp {}
 solders_traits_core::common_methods_default!(Memcmp);
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash)]
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 pub enum RpcFilterTypeFieldless {
     TokenAccountState,
 }

--- a/crates/rpc-requests/src/lib.rs
+++ b/crates/rpc-requests/src/lib.rs
@@ -86,7 +86,7 @@ Example:
      >>> " $name "(1, 2).to_json()
      '{\"method\":\"" $name:camel "\",\"jsonrpc\":\"2.0\",\"id\":2,\"params\":[1]}'
 "]
-                #[pyclass(module = "solders.rpc.requests")]
+                #[pyclass(from_py_object, module = "solders.rpc.requests")]
                 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
                 pub struct $name {
                     #[serde(flatten)]
@@ -130,7 +130,7 @@ Example:
      >>> " $name "(123).to_json()
      '{\"method\":\"" $name:camel "\",\"jsonrpc\":\"2.0\",\"id\":123}'
 "]
-                #[pyclass(module = "solders.rpc.requests")]
+                #[pyclass(from_py_object, module = "solders.rpc.requests")]
                 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
                 pub struct $name {
                     #[serde(flatten)]
@@ -180,7 +180,7 @@ unsubscribe_def!(VoteUnsubscribe);
 ///     >>> GetAccountInfo(Pubkey.default(), config).to_json()
 ///     '{"method":"getAccountInfo","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"encoding":"base64","dataSlice":null,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetAccountInfo {
     #[serde(flatten)]
@@ -230,7 +230,7 @@ request_boilerplate!(GetAccountInfo);
 ///     >>> GetBalance(Pubkey.default(), config).to_json()
 ///     '{"method":"getBalance","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"minContextSlot":1}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBalance {
     #[serde(flatten)]
@@ -281,7 +281,7 @@ request_boilerplate!(GetBalance);
 ///     >>> GetBlock(123, config).to_json()
 ///     '{"method":"getBlock","jsonrpc":"2.0","id":0,"params":[123,{"encoding":"base58","transactionDetails":"none","rewards":null,"maxSupportedTransactionVersion":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBlock {
     #[serde(flatten)]
@@ -330,7 +330,7 @@ request_boilerplate!(GetBlock);
 ///     >>> GetBlockHeight(config).to_json()
 ///     '{"method":"getBlockHeight","jsonrpc":"2.0","id":0,"params":[{"minContextSlot":123}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBlockHeight {
@@ -377,7 +377,7 @@ request_boilerplate!(GetBlockHeight);
 ///     >>> GetBlockProduction(config).to_json()
 ///     '{"method":"getBlockProduction","jsonrpc":"2.0","id":0,"params":[{"identity":"11111111111111111111111111111111","range":{"firstSlot":10,"lastSlot":15}}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetBlockProduction {
@@ -420,7 +420,7 @@ request_boilerplate!(GetBlockProduction);
 ///     >>> GetBlockCommitment(123).to_json()
 ///     '{"method":"getBlockCommitment","jsonrpc":"2.0","id":0,"params":[123]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBlockCommitment {
     #[serde(flatten)]
@@ -464,7 +464,7 @@ request_boilerplate!(GetBlockCommitment);
 ///     >>> GetBlocks(123, commitment=CommitmentLevel.Processed).to_json()
 ///     '{"method":"getBlocks","jsonrpc":"2.0","id":0,"params":[123,null,{"commitment":"processed"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBlocks {
     #[serde(flatten)]
@@ -525,7 +525,7 @@ request_boilerplate!(GetBlocks);
 ///     >>> GetBlocksWithLimit(123, 5, commitment=CommitmentLevel.Processed).to_json()
 ///     '{"method":"getBlocksWithLimit","jsonrpc":"2.0","id":0,"params":[123,5,{"commitment":"processed"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBlocksWithLimit {
     #[serde(flatten)]
@@ -583,7 +583,7 @@ request_boilerplate!(GetBlocksWithLimit);
 ///     >>> GetBlockTime(123).to_json()
 ///     '{"method":"getBlockTime","jsonrpc":"2.0","id":0,"params":[123]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetBlockTime {
     #[serde(flatten)]
@@ -629,7 +629,7 @@ zero_param_req_def!(GetClusterNodes);
 ///     >>> GetEpochInfo(config).to_json()
 ///     '{"method":"getEpochInfo","jsonrpc":"2.0","id":0,"params":[{"commitment":"processed","minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetEpochInfo {
@@ -677,7 +677,7 @@ zero_param_req_def!(GetEpochSchedule);
 ///     >>> GetFeeForMessage(MessageV0.default(), commitment=CommitmentLevel.Processed).to_json()
 ///     '{"method":"getFeeForMessage","jsonrpc":"2.0","id":0,"params":["gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",{"commitment":"processed"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetFeeForMessage {
     #[serde(flatten)]
@@ -736,7 +736,7 @@ zero_param_req_def!(ValidatorExit);
 ///     >>> GetInflationGovernor(CommitmentLevel.Finalized).to_json()
 ///     '{"method":"getInflationGovernor","jsonrpc":"2.0","id":0,"params":[{"commitment":"finalized"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetInflationGovernor {
@@ -785,7 +785,7 @@ zero_param_req_def!(GetInflationRate);
 ///     >>> GetInflationReward(addresses, config).to_json()
 ///     '{"method":"getInflationReward","jsonrpc":"2.0","id":0,"params":[["11111111111111111111111111111111","11111111111111111111111111111111"],{"epoch":1234,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetInflationReward {
     #[serde(flatten)]
@@ -837,7 +837,7 @@ request_boilerplate!(GetInflationReward);
 ///     >>> GetLargestAccounts(commitment=commitment, filter_=filter_).to_json()
 ///     '{"method":"getLargestAccounts","jsonrpc":"2.0","id":0,"params":[{"commitment":"processed"},"circulating"]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetLargestAccounts {
@@ -897,7 +897,7 @@ request_boilerplate!(GetLargestAccounts);
 ///     >>> GetLatestBlockhash(config).to_json()
 ///     '{"method":"getLatestBlockhash","jsonrpc":"2.0","id":0,"params":[{"commitment":"processed","minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetLatestBlockhash {
@@ -944,7 +944,7 @@ request_boilerplate!(GetLatestBlockhash);
 ///     >>> GetLeaderSchedule(123, config).to_json()
 ///     '{"method":"getLeaderSchedule","jsonrpc":"2.0","id":0,"params":[123,{"identity":"11111111111111111111111111111111"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetLeaderSchedule {
@@ -1000,7 +1000,7 @@ zero_param_req_def!(GetMaxShredInsertSlot);
 ///     >>> GetMinimumBalanceForRentExemption(50).to_json()
 ///     '{"method":"getMinimumBalanceForRentExemption","jsonrpc":"2.0","id":0,"params":[50]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetMinimumBalanceForRentExemption {
     #[serde(flatten)]
@@ -1056,7 +1056,7 @@ request_boilerplate!(GetMinimumBalanceForRentExemption);
 ///     >>> GetMultipleAccounts(accounts, config).to_json()
 ///     '{"method":"getMultipleAccounts","jsonrpc":"2.0","id":0,"params":[["11111111111111111111111111111111","11111111111111111111111111111111"],{"encoding":"base64+zstd","dataSlice":{"offset":10,"length":8},"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetMultipleAccounts {
     #[serde(flatten)]
@@ -1109,7 +1109,7 @@ request_boilerplate!(GetMultipleAccounts);
 ///     >>> GetProgramAccounts(Pubkey.default(), config).to_json()
 ///     '{"method":"getProgramAccounts","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"filters":[{"dataSize":10},{"memcmp":{"offset":10,"encoding":"bytes","bytes":[49,50,51]}}],"encoding":null,"dataSlice":null,"minContextSlot":null,"withContext":null,"sortResults":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetProgramAccounts {
     #[serde(flatten)]
@@ -1156,7 +1156,7 @@ request_boilerplate!(GetProgramAccounts);
 ///     >>> GetRecentPerformanceSamples(5).to_json()
 ///     '{"method":"getRecentPerformanceSamples","jsonrpc":"2.0","id":0,"params":[5]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetRecentPerformanceSamples {
@@ -1225,7 +1225,7 @@ impl Serialize for GetRecentPrioritizationFeesParams {
 ///     >>> GetRecentPrioritizationFees(addresses).to_json()
 ///     '{"method":"getRecentPrioritizationFees","jsonrpc":"2.0","id":0,"params":[["11111111111111111111111111111111","11111111111111111111111111111111"]]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetRecentPrioritizationFees {
@@ -1271,7 +1271,7 @@ request_boilerplate!(GetRecentPrioritizationFees);
 ///     >>> GetSignaturesForAddress(Pubkey.default(), config).to_json()
 ///     '{"method":"getSignaturesForAddress","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"before":null,"until":null,"limit":10,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetSignaturesForAddress {
     #[serde(flatten)]
@@ -1326,7 +1326,7 @@ request_boilerplate!(GetSignaturesForAddress);
 ///     >>> GetSignatureStatuses([Signature.default()], config).to_json()
 ///     '{"method":"getSignatureStatuses","jsonrpc":"2.0","id":0,"params":[["1111111111111111111111111111111111111111111111111111111111111111"],{"searchTransactionHistory":true}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetSignatureStatuses {
     #[serde(flatten)]
@@ -1379,7 +1379,7 @@ request_boilerplate!(GetSignatureStatuses);
 ///     >>> GetSlot(config).to_json()
 ///     '{"method":"getSlot","jsonrpc":"2.0","id":0,"params":[{"minContextSlot":123}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetSlot {
@@ -1424,7 +1424,7 @@ request_boilerplate!(GetSlot);
 ///     >>> GetSlotLeader(config).to_json()
 ///     '{"method":"getSlotLeader","jsonrpc":"2.0","id":0,"params":[{"minContextSlot":123}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetSlotLeader {
@@ -1468,7 +1468,7 @@ request_boilerplate!(GetSlotLeader);
 ///     >>> GetSlotLeaders(100, 10).to_json()
 ///     '{"method":"getSlotLeaders","jsonrpc":"2.0","id":0,"params":[100,10]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetSlotLeaders {
     #[serde(flatten)]
@@ -1517,7 +1517,7 @@ request_boilerplate!(GetSlotLeaders);
 ///     >>> GetStakeMinimumDelegation(config).to_json()
 ///     '{"method":"getStakeMinimumDelegation","jsonrpc":"2.0","id":0,"params":[{"minContextSlot":123}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetStakeMinimumDelegation {
@@ -1562,7 +1562,7 @@ request_boilerplate!(GetStakeMinimumDelegation);
 ///     >>> GetSupply(config).to_json()
 ///     '{"method":"getSupply","jsonrpc":"2.0","id":0,"params":[{"excludeNonCirculatingAccountsList":true}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetSupply {
@@ -1608,7 +1608,7 @@ request_boilerplate!(GetSupply);
 ///     >>> GetTokenAccountBalance(Pubkey.default(), CommitmentLevel.Processed).to_json()
 ///     '{"method":"getTokenAccountBalance","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"commitment":"processed"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTokenAccountBalance {
     #[serde(flatten)]
@@ -1667,7 +1667,7 @@ request_boilerplate!(GetTokenAccountBalance);
 ///         ),
 ///     )
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTokenAccountsByDelegate {
     #[serde(flatten)]
@@ -1738,7 +1738,7 @@ request_boilerplate!(GetTokenAccountsByDelegate);
 ///         ),
 ///     )
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTokenAccountsByOwner {
     #[serde(flatten)]
@@ -1798,7 +1798,7 @@ request_boilerplate!(GetTokenAccountsByOwner);
 ///     >>> GetTokenLargestAccounts(Pubkey.default()).to_json()
 ///     '{"method":"getTokenLargestAccounts","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111"]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTokenLargestAccounts {
     #[serde(flatten)]
@@ -1847,7 +1847,7 @@ request_boilerplate!(GetTokenLargestAccounts);
 ///     >>> GetTokenSupply(Pubkey.default()).to_json()
 ///     '{"method":"getTokenSupply","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111"]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTokenSupply {
     #[serde(flatten)]
@@ -1898,7 +1898,7 @@ request_boilerplate!(GetTokenSupply);
 ///     >>> GetTransaction(Signature.default(), config).to_json()
 ///     '{"method":"getTransaction","jsonrpc":"2.0","id":0,"params":["1111111111111111111111111111111111111111111111111111111111111111",{"encoding":null,"maxSupportedTransactionVersion":1}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTransaction {
     #[serde(flatten)]
@@ -1947,7 +1947,7 @@ request_boilerplate!(GetTransaction);
 ///     >>> GetTransactionCount(config).to_json()
 ///     '{"method":"getTransactionCount","jsonrpc":"2.0","id":0,"params":[{"minContextSlot":1234}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetTransactionCount {
@@ -1993,7 +1993,7 @@ zero_param_req_def!(GetVersion);
 ///     >>> GetVoteAccounts(config).to_json()
 ///     '{"method":"getVoteAccounts","jsonrpc":"2.0","id":0,"params":[{"votePubkey":null,"keepUnstakedDelinquents":false,"delinquentSlotDistance":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetVoteAccounts {
@@ -2038,7 +2038,7 @@ request_boilerplate!(GetVoteAccounts);
 ///     >>> IsBlockhashValid(Hash.default()).to_json()
 ///     '{"method":"isBlockhashValid","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111"]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct IsBlockhashValid {
     #[serde(flatten)]
@@ -2092,7 +2092,7 @@ zero_param_req_def!(MinimumLedgerSlot);
 ///      >>> RequestAirdrop(Pubkey.default(), 1000, config).to_json()
 ///      '{"method":"requestAirdrop","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",1000,{"recentBlockhash":null,"commitment":"confirmed"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct RequestAirdrop {
     #[serde(flatten)]
@@ -2171,7 +2171,7 @@ request_boilerplate!(RequestAirdrop);
 ///      >>> SendVersionedTransaction(tx, config).to_json()
 ///      '{"method":"sendTransaction","jsonrpc":"2.0","id":0,"params":["AaVkKDb3UlpidO/ucBnOcmS+1dY8ZAC4vHxTxiccV8zPBlupuozppRjwrILZJaoKggAcVSD1XlAKstDVEPFOVgwBAAECiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAA2FiYw==",{"skipPreflight":false,"preflightCommitment":"confirmed","encoding":"base64","maxRetries":null,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SendVersionedTransaction {
     #[serde(flatten)]
@@ -2243,7 +2243,7 @@ request_boilerplate!(SendVersionedTransaction);
 ///      >>> SendLegacyTransaction(tx, config).to_json()
 ///      '{"method":"sendTransaction","jsonrpc":"2.0","id":0,"params":["AaVkKDb3UlpidO/ucBnOcmS+1dY8ZAC4vHxTxiccV8zPBlupuozppRjwrILZJaoKggAcVSD1XlAKstDVEPFOVgwBAAECiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAA2FiYw==",{"skipPreflight":false,"preflightCommitment":"confirmed","encoding":"base64","maxRetries":null,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SendLegacyTransaction {
     #[serde(flatten)]
@@ -2310,7 +2310,7 @@ request_boilerplate!(SendLegacyTransaction);
 ///      >>> SendRawTransaction(bytes(tx), config).to_json()
 ///      '{"method":"sendTransaction","jsonrpc":"2.0","id":0,"params":["AaVkKDb3UlpidO/ucBnOcmS+1dY8ZAC4vHxTxiccV8zPBlupuozppRjwrILZJaoKggAcVSD1XlAKstDVEPFOVgwBAAECiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAA2FiYw==",{"skipPreflight":false,"preflightCommitment":"confirmed","encoding":"base64","maxRetries":null,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SendRawTransaction {
     #[serde(flatten)]
@@ -2380,7 +2380,7 @@ request_boilerplate!(SendRawTransaction);
 ///      >>> SimulateLegacyTransaction(tx, config).to_json()
 ///      '{"method":"simulateTransaction","jsonrpc":"2.0","id":0,"params":["AaVkKDb3UlpidO/ucBnOcmS+1dY8ZAC4vHxTxiccV8zPBlupuozppRjwrILZJaoKggAcVSD1XlAKstDVEPFOVgwBAAECiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAA2FiYw==",{"sigVerify":false,"replaceRecentBlockhash":false,"commitment":"confirmed","encoding":"base64","accounts":{"encoding":"base64+zstd","addresses":["11111111111111111111111111111111"]},"minContextSlot":null,"innerInstructions":false}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SimulateLegacyTransaction {
     #[serde(flatten)]
@@ -2450,7 +2450,7 @@ request_boilerplate!(SimulateLegacyTransaction);
 ///      >>> SimulateVersionedTransaction(tx, config).to_json()
 ///      '{"method":"simulateTransaction","jsonrpc":"2.0","id":0,"params":["AAEAAQKKiOPddAnxlf1S2y08ul1yymcJvx2UEhvzdIgBtA9vXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQADYWJj",{"sigVerify":false,"replaceRecentBlockhash":false,"commitment":"confirmed","encoding":"base64","accounts":{"encoding":"base64+zstd","addresses":["11111111111111111111111111111111"]},"minContextSlot":null,"innerInstructions":false}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SimulateVersionedTransaction {
     #[serde(flatten)]
@@ -2506,7 +2506,7 @@ request_boilerplate!(SimulateVersionedTransaction);
 ///     >>> AccountSubscribe(Pubkey.default(), config).to_json()
 ///     '{"method":"accountSubscribe","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"encoding":"base64","dataSlice":null,"minContextSlot":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct AccountSubscribe {
     #[serde(flatten)]
@@ -2561,7 +2561,7 @@ request_boilerplate!(AccountSubscribe);
 ///      >>> BlockSubscribe(RpcBlockSubscribeFilterMentions(Pubkey.default()), config).to_json()
 ///      '{"method":"blockSubscribe","jsonrpc":"2.0","id":0,"params":[{"mentionsAccountOrProgram":"11111111111111111111111111111111"},{"encoding":null,"transactionDetails":"signatures","showRewards":null,"maxSupportedTransactionVersion":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct BlockSubscribe {
     #[serde(flatten)]
@@ -2619,7 +2619,7 @@ request_boilerplate!(BlockSubscribe);
 ///      >>> LogsSubscribe(RpcTransactionLogsFilterMentions(Pubkey.default()), config).to_json()
 ///      '{"method":"logsSubscribe","jsonrpc":"2.0","id":0,"params":[{"mentions":["11111111111111111111111111111111"]},{"commitment":"confirmed"}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LogsSubscribe {
     #[serde(flatten)]
@@ -2677,7 +2677,7 @@ request_boilerplate!(LogsSubscribe);
 ///     >>> ProgramSubscribe(Pubkey.default(), config).to_json()
 ///     '{"method":"programSubscribe","jsonrpc":"2.0","id":0,"params":["11111111111111111111111111111111",{"filters":[{"dataSize":10},{"memcmp":{"offset":10,"encoding":"bytes","bytes":[49,50,51]}}],"encoding":null,"dataSlice":null,"minContextSlot":null,"withContext":null,"sortResults":null}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ProgramSubscribe {
     #[serde(flatten)]
@@ -2728,7 +2728,7 @@ request_boilerplate!(ProgramSubscribe);
 ///      >>> SignatureSubscribe(Signature.default(), config).to_json()
 ///      '{"method":"signatureSubscribe","jsonrpc":"2.0","id":0,"params":["1111111111111111111111111111111111111111111111111111111111111111",{"enableReceivedNotification":false}]}'
 ///
-#[pyclass(module = "solders.rpc.requests")]
+#[pyclass(from_py_object, module = "solders.rpc.requests")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SignatureSubscribe {
     #[serde(flatten)]

--- a/crates/rpc-responses-common/src/lib.rs
+++ b/crates/rpc-responses-common/src/lib.rs
@@ -25,7 +25,7 @@ use solders_rpc_response_data_boilerplate::response_data_boilerplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcResponseContext {
     #[pyo3(get)]
     pub slot: u64,
@@ -51,7 +51,7 @@ response_data_boilerplate!(RpcResponseContext);
 macro_rules! contextful_struct_def_eq {
     ($name:ident, $inner:ty) => {
         #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name {
             #[pyo3(get)]
             context: RpcResponseContext,
@@ -62,7 +62,7 @@ macro_rules! contextful_struct_def_eq {
     ($name:ident, $inner:ty, $serde_as:expr) => {
         #[serde_as]
         #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name {
             #[pyo3(get)]
             context: RpcResponseContext,
@@ -77,7 +77,7 @@ macro_rules! contextful_struct_def_eq {
 macro_rules! contextful_struct_def_no_eq {
     ($name:ident, $inner:ty) => {
         #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name {
             #[pyo3(get)]
             context: RpcResponseContext,
@@ -88,7 +88,7 @@ macro_rules! contextful_struct_def_no_eq {
     ($name:ident, $inner:ty, $serde_as:expr) => {
         #[serde_as]
         #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name {
             #[pyo3(get)]
             context: RpcResponseContext,
@@ -104,7 +104,7 @@ macro_rules! notification_struct_def_outer {
     ($name:ident) => {
         paste! {
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct $name {
                 #[pyo3(get)]
                 result: [<$name Result>],
@@ -120,7 +120,7 @@ macro_rules! notification_struct_def_outer_no_eq {
     ($name:ident) => {
         paste! {
             #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct $name {
                 #[pyo3(get)]
                 result: [<$name Result>],
@@ -137,7 +137,7 @@ macro_rules! notification_struct_def {
         notification_struct_def_outer!($name);
         paste! {
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct [<$name Result>] {
                 #[pyo3(get)]
                 context: RpcResponseContext,
@@ -151,7 +151,7 @@ macro_rules! notification_struct_def {
         paste! {
             #[serde_as]
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct [<$name Result>] {
                 #[pyo3(get)]
                 context: RpcResponseContext,
@@ -167,7 +167,7 @@ macro_rules! notification_struct_def {
 macro_rules! notification_struct_def_contextless {
     ($name:ident, $inner:ty) => {
         #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name {
             #[pyo3(get)]
             result: $inner,
@@ -183,7 +183,7 @@ macro_rules! notification_struct_def_no_eq {
         notification_struct_def_outer_no_eq!($name);
         paste! {
             #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct [<$name Result>] {
                 #[pyo3(get)]
                 context: RpcResponseContext,
@@ -267,7 +267,7 @@ macro_rules! notification_contextless {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcIdentity(RpcIdentityOriginal);
 
 response_data_boilerplate!(RpcIdentity);
@@ -292,7 +292,7 @@ impl RpcIdentity {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcBlockhash(RpcBlockhashOriginal);
 //     #[serde_as(as = "DisplayFromStr")]
 //     #[pyo3(get)]
@@ -391,7 +391,7 @@ impl From<AccountMaybeJSON> for UiAccount {
 // TODO: make the one in solana-rpc-client-api work here.
 #[serde_as]
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcKeyedAccount {
     #[serde_as(as = "DisplayFromStr")]
@@ -416,7 +416,7 @@ impl RpcKeyedAccount {
 
 #[serde_as]
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcKeyedAccountJsonParsed {
     #[serde_as(as = "DisplayFromStr")]
@@ -447,7 +447,7 @@ pub enum RpcKeyedAccountMaybeJSON {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcTokenAccountBalance(RpcTokenAccountBalanceOriginal);
 
 response_data_boilerplate!(RpcTokenAccountBalance);
@@ -476,7 +476,7 @@ impl RpcTokenAccountBalance {
     }
 }
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcVersionInfo(RpcVersionInfoOriginal);
 
 response_data_boilerplate!(RpcVersionInfo);
@@ -506,7 +506,7 @@ impl RpcVersionInfo {
     }
 }
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcVoteAccountInfo(RpcVoteAccountInfoOriginal);
 
 response_data_boilerplate!(RpcVoteAccountInfo);
@@ -573,7 +573,7 @@ impl RpcVoteAccountInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcVoteAccountStatus(RpcVoteAccountStatusOriginal);
 
 response_data_boilerplate!(RpcVoteAccountStatus);
@@ -612,7 +612,7 @@ impl RpcVoteAccountStatus {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcSignatureResponse {
     #[pyo3(get)]
     err: Option<TransactionErrorType>,
@@ -632,13 +632,13 @@ impl RpcSignatureResponse {
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, Eq, PartialEq)]
-#[pyclass(module = "solders.rpc.responses", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", eq, eq_int)]
 pub enum BlockStoreError {
     BlockStoreError,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct SubscriptionResult {
     #[serde(skip_deserializing)]
     jsonrpc: solders_rpc_version::V2,
@@ -665,7 +665,7 @@ impl SubscriptionResult {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct UnsubscribeResult {
     #[serde(skip_deserializing)]
     jsonrpc: solders_rpc_version::V2,

--- a/crates/rpc-responses-tx-status/src/lib.rs
+++ b/crates/rpc-responses-tx-status/src/lib.rs
@@ -12,7 +12,7 @@ use solders_transaction_confirmation_status::TransactionConfirmationStatus;
 use solders_transaction_error::TransactionErrorType;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcConfirmedTransactionStatusWithSignature(
     RpcConfirmedTransactionStatusWithSignatureOriginal,
 );

--- a/crates/rpc-responses/src/lib.rs
+++ b/crates/rpc-responses/src/lib.rs
@@ -151,7 +151,7 @@ macro_rules! resp_traits {
 macro_rules! contextless_struct_def_no_eq {
     ($name:ident, $inner:ty) => {
         #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name($inner);
         resp_traits!($name);
     };
@@ -160,14 +160,14 @@ macro_rules! contextless_struct_def_no_eq {
 macro_rules! contextless_struct_def_eq {
     ($name:ident, $inner:ty) => {
         #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name($inner);
         resp_traits!($name);
     };
     ($name:ident, $inner:ty, $serde_as:expr) => {
         #[serde_as]
         #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-        #[pyclass(module = "solders.rpc.responses", subclass)]
+        #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
         pub struct $name(#[serde_as(as = $serde_as)] $inner);
         resp_traits!($name);
     };
@@ -764,7 +764,7 @@ contextful_resp_eq!(
 contextful_resp_eq!(GetBalanceResp, u64);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcBlockCommitment(RpcBlockCommitmentOriginal<[u64; 32]>);
 
 response_data_boilerplate!(RpcBlockCommitment);
@@ -798,7 +798,7 @@ contextless_resp_eq!(GetBlockCommitmentResp, RpcBlockCommitment, clone);
 contextless_resp_eq!(GetBlockHeightResp, u64);
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcBlockProductionRange(RpcBlockProductionRangeOriginal);
 
 response_data_boilerplate!(RpcBlockProductionRange);
@@ -828,7 +828,7 @@ impl RpcBlockProductionRange {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcBlockProduction(RpcBlockProductionOriginal);
 
 response_data_boilerplate!(RpcBlockProduction);
@@ -881,7 +881,7 @@ contextless_resp_methods_no_clone_nullable!(GetBlockTimeResp, Option<u64>);
 #[serde_as]
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug, From, Into)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcContactInfo(pub RpcContactInfoOriginal);
 
 response_data_boilerplate!(RpcContactInfo);
@@ -1010,7 +1010,7 @@ contextless_resp_eq!(GetGenesisHashResp, SolderHash, "DisplayFromStr");
 contextless_resp_eq!(GetHealthResp, String, clone);
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcSnapshotSlotInfo(RpcSnapshotSlotInfoOriginal);
 
 response_data_boilerplate!(RpcSnapshotSlotInfo);
@@ -1040,7 +1040,7 @@ contextless_resp_eq!(GetHighestSnapshotSlotResp, RpcSnapshotSlotInfo, clone);
 contextless_resp_eq!(GetIdentityResp, RpcIdentity, clone);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcInflationGovernor(RpcInflationGovernorOriginal);
 
 response_data_boilerplate!(RpcInflationGovernor);
@@ -1092,7 +1092,7 @@ impl RpcInflationGovernor {
 contextless_resp_no_eq!(GetInflationGovernorResp, RpcInflationGovernor, clone);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcInflationRate(RpcInflationRateOriginal);
 
 response_data_boilerplate!(RpcInflationRate);
@@ -1133,7 +1133,7 @@ impl RpcInflationRate {
 contextless_resp_no_eq!(GetInflationRateResp, RpcInflationRate, clone);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcInflationReward(RpcInflationRewardOriginal);
 
 response_data_boilerplate!(RpcInflationReward);
@@ -1195,7 +1195,7 @@ contextless_resp_eq!(
 );
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcAccountBalance(RpcAccountBalanceOriginal);
 
 response_data_boilerplate!(RpcAccountBalance);
@@ -1276,7 +1276,7 @@ contextless_resp_eq!(
 );
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcPerfSample(RpcPerfSampleOriginal);
 
 response_data_boilerplate!(RpcPerfSample);
@@ -1329,7 +1329,7 @@ impl RpcPerfSample {
 contextless_resp_eq!(GetRecentPerformanceSamplesResp, Vec<RpcPerfSample>, clone);
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcPrioritizationFee(RpcPrioritizationFeeOriginal);
 
 response_data_boilerplate!(RpcPrioritizationFee);
@@ -1389,7 +1389,7 @@ contextless_resp_eq!(
 contextful_resp_eq!(GetStakeMinimumDelegationResp, u64);
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcSupply(RpcSupplyOriginal);
 
 response_data_boilerplate!(RpcSupply);
@@ -1466,7 +1466,7 @@ contextless_resp_eq!(GetTransactionCountResp, u64);
 contextless_resp_eq!(GetVersionResp, RpcVersionInfo, clone);
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcLogsResponse(RpcLogsResponseOriginal);
 
 response_data_boilerplate!(RpcLogsResponse);
@@ -1509,7 +1509,7 @@ impl RpcLogsResponse {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct SlotTransactionStats(SlotTransactionStatsOriginal);
 
 response_data_boilerplate!(SlotTransactionStats);
@@ -1554,7 +1554,7 @@ impl SlotTransactionStats {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct SlotInfo(SlotInfoOriginal);
 
 response_data_boilerplate!(SlotInfo);
@@ -1586,7 +1586,7 @@ macro_rules! slot_update_core {
     ($name:ident) => {
         paste! {
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct [<SlotUpdate $name>] {
                 #[pyo3(get)]
                 slot: Slot,
@@ -1616,7 +1616,7 @@ macro_rules! slot_update_core {
     ($name:ident, $param:ident : $type:ty) => {
         paste! {
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-            #[pyclass(module = "solders.rpc.responses", subclass)]
+            #[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
             pub struct [<SlotUpdate $name>] {
                 #[pyo3(get)]
                 slot: Slot,
@@ -1751,7 +1751,7 @@ impl From<SlotUpdateOriginal> for SlotUpdate {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcVote(RpcVoteOriginal);
 
 response_data_boilerplate!(RpcVote);
@@ -1834,7 +1834,7 @@ impl From<RpcBlockUpdateErrorOriginal> for RpcBlockUpdateError {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct RpcBlockUpdate(RpcBlockUpdateOriginal);
 
 response_data_boilerplate!(RpcBlockUpdate);
@@ -1872,7 +1872,7 @@ impl RpcBlockUpdate {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-#[pyclass(module = "solders.rpc.responses", subclass)]
+#[pyclass(from_py_object, module = "solders.rpc.responses", subclass)]
 pub struct SubscriptionError {
     #[serde(skip_deserializing)]
     jsonrpc: solders_rpc_version::V2,

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -12,7 +12,7 @@ use solders_traits_core::{
     PyFromBytesGeneral, PyHash, RichcmpFull,
 };
 
-#[pyclass(module = "solders.signature", subclass)]
+#[pyclass(from_py_object, module = "solders.signature", subclass)]
 #[derive(
     Clone,
     Copy,

--- a/crates/token/src/state.rs
+++ b/crates/token/src/state.rs
@@ -48,7 +48,7 @@ macro_rules! token_boilerplate {
 ///     is_initialized (bool): Is ``True`` if this structure has been initialized.
 ///     freeze_authority (Optional[Pubkey]): Optional authority to freeze token accounts.
 ///
-#[pyclass(module = "solders.token.state", subclass)]
+#[pyclass(from_py_object, module = "solders.token.state", subclass)]
 #[derive(Clone, Copy, Debug, PartialEq, Default, From, Into)]
 pub struct Mint(pub MintOriginal);
 
@@ -120,7 +120,7 @@ impl Mint {
 token_boilerplate!(Mint, MintOriginal);
 
 /// Token account state.
-#[pyclass(module = "solders.token.state", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.token.state", eq, eq_int)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[enum_original_mapping(AccountState)]
 pub enum TokenAccountState {
@@ -151,7 +151,7 @@ pub enum TokenAccountState {
 ///     delegated_amount (int): The amount delegated.
 ///     close_authority (Optional[Pubkey]): Optional authority to close the account.
 ///
-#[pyclass(module = "solders.token.state", subclass)]
+#[pyclass(from_py_object, module = "solders.token.state", subclass)]
 #[derive(Clone, Copy, Debug, PartialEq, Default, From, Into)]
 pub struct TokenAccount(pub TokenAccountOriginal);
 
@@ -255,7 +255,7 @@ token_boilerplate!(TokenAccount, TokenAccountOriginal);
 ///     is_initialized (bool): Is ``True`` if this structure has been initialized.
 ///     signers (Sequence[Pubkey]): Signer public keys.
 ///
-#[pyclass(module = "solders.token.state", subclass)]
+#[pyclass(from_py_object, module = "solders.token.state", subclass)]
 #[derive(Clone, Copy, Debug, PartialEq, Default, From, Into)]
 pub struct Multisig(pub MultisigOriginal);
 

--- a/crates/transaction-confirmation-status/src/lib.rs
+++ b/crates/transaction-confirmation-status/src/lib.rs
@@ -6,7 +6,7 @@ use solders_macros::enum_original_mapping;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[enum_original_mapping(TransactionConfirmationStatusOriginal)]
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 pub enum TransactionConfirmationStatus {
     Processed,
     Confirmed,

--- a/crates/transaction-error/src/lib.rs
+++ b/crates/transaction-error/src/lib.rs
@@ -12,7 +12,7 @@ use {
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct InstructionErrorCustom(pub u32);
 
 transaction_status_boilerplate!(InstructionErrorCustom);
@@ -33,7 +33,7 @@ impl InstructionErrorCustom {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct InstructionErrorBorshIO(pub String);
 transaction_status_boilerplate!(InstructionErrorBorshIO);
 
@@ -53,7 +53,7 @@ impl InstructionErrorBorshIO {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 pub enum InstructionErrorFieldless {
     GenericError,
     InvalidArgument,
@@ -378,7 +378,7 @@ impl From<InstructionErrorOriginal> for InstructionErrorType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct TransactionErrorInstructionError(pub (u8, InstructionErrorType));
 transaction_status_boilerplate!(TransactionErrorInstructionError);
 
@@ -403,7 +403,7 @@ impl TransactionErrorInstructionError {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct TransactionErrorDuplicateInstruction(pub u8);
 transaction_status_boilerplate!(TransactionErrorDuplicateInstruction);
 
@@ -423,7 +423,7 @@ impl TransactionErrorDuplicateInstruction {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct TransactionErrorInsufficientFundsForRent {
     #[pyo3(get)]
     account_index: u8,
@@ -441,7 +441,7 @@ impl TransactionErrorInsufficientFundsForRent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct TransactionErrorProgramExecutionTemporarilyRestricted {
     #[pyo3(get)]
     account_index: u8,
@@ -458,7 +458,7 @@ impl TransactionErrorProgramExecutionTemporarilyRestricted {
     }
 }
 
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TransactionErrorFieldless {
     AccountInUse,

--- a/crates/transaction-return-data/src/lib.rs
+++ b/crates/transaction-return-data/src/lib.rs
@@ -11,7 +11,7 @@ use solana_transaction_status_client_types::{UiReturnDataEncoding, UiTransaction
 use solders_macros::{common_methods, richcmp_eq_only};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct TransactionReturnData(pub TransactionReturnDataOriginal);
 transaction_status_boilerplate!(TransactionReturnData);
 

--- a/crates/transaction-status-enums/src/lib.rs
+++ b/crates/transaction-status-enums/src/lib.rs
@@ -9,7 +9,7 @@ use solders_macros::enum_original_mapping;
 /// Levels of transaction detail to return in RPC requests.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 pub enum TransactionDetails {
     Full,
     Signatures,
@@ -47,7 +47,7 @@ impl From<TransactionDetailsOriginal> for TransactionDetails {
 }
 
 /// Encoding options for transaction data.
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[enum_original_mapping(UiTransactionEncodingOriginal)]

--- a/crates/transaction-status-struct/src/lib.rs
+++ b/crates/transaction-status-struct/src/lib.rs
@@ -11,7 +11,7 @@ use solana_transaction_status_client_types::TransactionStatus as TransactionStat
 use solders_macros::{common_methods, richcmp_eq_only};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct TransactionStatus(pub TransactionStatusOriginal);
 
 transaction_status_boilerplate!(TransactionStatus);

--- a/crates/transaction-status/src/lib.rs
+++ b/crates/transaction-status/src/lib.rs
@@ -53,14 +53,14 @@ use solders_transaction::{TransactionVersion, VersionedTransaction};
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[enum_original_mapping(TransactionBinaryEncodingOriginal)]
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 pub enum TransactionBinaryEncoding {
     Base58,
     Base64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiCompiledInstruction(UiCompiledInstructionOriginal);
 
 transaction_status_boilerplate!(UiCompiledInstruction);
@@ -108,7 +108,7 @@ impl UiCompiledInstruction {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiAddressTableLookup(UiAddressTableLookupOriginal);
 
 transaction_status_boilerplate!(UiAddressTableLookup);
@@ -145,7 +145,7 @@ impl UiAddressTableLookup {
 
 /// A duplicate representation of a Message, in raw format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiRawMessage(UiRawMessageOriginal);
 
 transaction_status_boilerplate!(UiRawMessage);
@@ -212,7 +212,7 @@ impl UiRawMessage {
     }
 }
 
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 #[enum_original_mapping(ParsedAccountSourceOriginal)]
@@ -222,7 +222,7 @@ pub enum ParsedAccountSource {
 }
 /// A duplicate representation of a Message, in raw format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct ParsedAccountTxStatus(ParsedAccountOriginal);
 
 transaction_status_boilerplate!(ParsedAccountTxStatus);
@@ -270,7 +270,7 @@ impl ParsedAccountTxStatus {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct ParsedInstruction(ParsedInstructionOriginal);
 
 transaction_status_boilerplate!(ParsedInstruction);
@@ -319,7 +319,7 @@ impl ParsedInstruction {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiPartiallyDecodedInstruction(UiPartiallyDecodedInstructionOriginal);
 
 transaction_status_boilerplate!(UiPartiallyDecodedInstruction);
@@ -424,7 +424,7 @@ impl From<UiInstructionOriginal> for UiInstruction {
 
 /// A duplicate representation of a Message, in raw format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiParsedMessage(UiParsedMessageOriginal);
 
 transaction_status_boilerplate!(UiParsedMessage);
@@ -511,7 +511,7 @@ impl From<UiMessage> for UiMessageOriginal {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiTransaction(UiTransactionOriginal);
 
 transaction_status_boilerplate!(UiTransaction);
@@ -590,7 +590,7 @@ impl From<EncodedTransactionOriginal> for EncodedVersionedTransaction {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiAccountsList(UiAccountsListOriginal);
 
 transaction_status_boilerplate!(UiAccountsList);
@@ -661,7 +661,7 @@ impl From<EncodedTransaction> for EncodedTransactionOriginal {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiInnerInstructions(UiInnerInstructionsOriginal);
 
 transaction_status_boilerplate!(UiInnerInstructions);
@@ -696,7 +696,7 @@ impl UiInnerInstructions {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiLoadedAddresses(UiLoadedAddressesOriginal);
 
 transaction_status_boilerplate!(UiLoadedAddresses);
@@ -734,7 +734,7 @@ impl UiLoadedAddresses {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiTransactionTokenBalance(UiTransactionTokenBalanceOriginal);
 
 transaction_status_boilerplate!(UiTransactionTokenBalance);
@@ -790,7 +790,7 @@ impl UiTransactionTokenBalance {
     }
 }
 
-#[pyclass(module = "solders.transaction_status", eq, eq_int)]
+#[pyclass(from_py_object, module = "solders.transaction_status", eq, eq_int)]
 #[enum_original_mapping(RewardTypeOriginal)]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
@@ -802,7 +802,7 @@ pub enum RewardType {
 }
 /// A duplicate representation of TransactionStatusMeta with `err` field
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiTransactionStatusMeta(UiTransactionStatusMetaOriginal);
 impl RichcmpEqualityOnly for UiTransactionStatusMeta {
     fn richcmp(&self, other: &Self, op: pyo3::pyclass::CompareOp) -> PyResult<bool> {
@@ -964,7 +964,7 @@ impl UiTransactionStatusMeta {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct EncodedTransactionWithStatusMeta(EncodedTransactionWithStatusMetaOriginal);
 
 transaction_status_boilerplate!(EncodedTransactionWithStatusMeta);
@@ -1005,7 +1005,7 @@ impl EncodedTransactionWithStatusMeta {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct Reward(RewardOriginal);
 
 transaction_status_boilerplate!(Reward);
@@ -1071,7 +1071,7 @@ pub type Rewards = Vec<Reward>;
 // the one in transaction_status is missing Clone
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct EncodedConfirmedTransactionWithStatusMeta {
     #[pyo3(get)]
     pub slot: u64,
@@ -1109,7 +1109,7 @@ impl EncodedConfirmedTransactionWithStatusMeta {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, From, Into)]
-#[pyclass(module = "solders.transaction_status", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction_status", subclass)]
 pub struct UiConfirmedBlock(UiConfirmedBlockOriginal);
 
 transaction_status_boilerplate!(UiConfirmedBlock);

--- a/crates/transaction/src/lib.rs
+++ b/crates/transaction/src/lib.rs
@@ -38,7 +38,7 @@ use solders_signature::{originals_into_solders, solders_into_originals, Signatur
 ///     message (Message | MessageV0): The message to sign.
 ///     keypairs (Sequence[Keypair | Presigner]): The keypairs that are to sign the transaction.
 #[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize, From, Into)]
-#[pyclass(module = "solders.transaction", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction", subclass)]
 pub struct VersionedTransaction(pub VersionedTransactionOriginal);
 
 impl From<Transaction> for VersionedTransaction {
@@ -175,7 +175,7 @@ impl VersionedTransaction {
     }
 }
 
-#[pyclass(module = "solders.transaction", subclass)]
+#[pyclass(from_py_object, module = "solders.transaction", subclass)]
 #[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize, From, Into)]
 /// An atomically-commited sequence of instructions.
 ///
@@ -705,7 +705,7 @@ impl AsRef<TransactionOriginal> for Transaction {
 /// Transaction version type that serializes to the string "legacy"
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[pyclass(module = "solders.transaction")]
+#[pyclass(from_py_object, module = "solders.transaction")]
 pub enum Legacy {
     Legacy,
 }


### PR DESCRIPTION
pyo3 0.26 → 0.29, pythonize 0.26 → 0.29. `abi3-py38` is retained, so the minimum Python version is unchanged. The Python API and behaviour are unchanged; tests, stubs, and doctests are untouched.

Most of the diff is mechanical. The substantive parts:

### `dict-derive` rewrite
`crates/dict-derive/src/from.rs` has the only new logic. pyo3 0.27 reworked `FromPyObject`: two lifetimes (`FromPyObject<'a, 'py>`), an associated `Error` type, and `extract(Borrowed<…>)` in place of `extract_bound(&Bound<…>)`. The derive is rewritten to match, following pyo3's own derive output. Three points:
- field helpers are bounded `T: for<'a> FromPyObject<'a, 'py>` (HRTB), since the input lifetime is now independent of `'py`;
- `cast()` returns `Borrowed`, so the generated code passes `&dict` and relies on deref coercion to `&Bound`;
- `extract::<T>()` needs a turbofish; inference can't see through the `map_err` to the field type.

The `*Params` round-trip tests cover this derive.

### `FromPyObject` opt-in
0.29 deprecates the automatic `FromPyObject` impl for `Clone` `#[pyclass]` types. Each gets `#[pyclass(from_py_object)]`, preserving current behaviour: the types stay extractable from Python (usable as function arguments). A future pyo3 will make opting out the default, so the explicit annotation also stops these types silently losing extraction later. Macro-generated pyclasses are handled at their macro definitions. The two non-Clone pyclasses (`LiteSVM`, `SlotHistoryCheck`) never had the impl and are unchanged.

Types that are only returned, never extracted, could use `skip_from_py_object` instead to keep the API minimal. Left for later.

### serde `derive` feature
Now explicit on the workspace dep. It was only enabled transitively, which is fragile: a dependency-graph shift can drop it and break the serde derives (the non-litesvm config hits this). Worth keeping regardless of pyo3.
