### PR TITLE
Update litesvm to 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Raise the minimum supported Python version to 3.10 (was 3.8). Python 3.8 and 3.9 are end-of-life.
+- Update litesvm to 0.13.1, which refreshes the simulated mainnet feature set to match the cluster as of 2026-06-30
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "litesvm"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55763dae5b5f992c34eb39c49333f90dd6d5b851f878429ed2b08667b329baee"
+checksum = "f1e00083aad2a7aa9d6900454604f7776da40be57304e5119f09222a1e9b105a"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -1620,7 +1620,7 @@ dependencies = [
  "qualifier_attr",
  "serde",
  "solana-account",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
  "solana-builtins",
@@ -2527,7 +2527,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -2538,14 +2538,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c5d02824391b072dc5cd0aaa85fb0af9784a21d23286a767994d1e8a322131"
+checksum = "5f08236dacd0e6dc8234becef58e27c8567856644ef509d7e97957d55a91dc72"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -3059,7 +3059,7 @@ dependencies = [
  "five8 1.0.0",
  "five8_core 1.0.0",
  "rand 0.9.4",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -3144,7 +3144,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-hash 4.2.0",
  "solana-instruction",
  "solana-sanitize",
@@ -3341,7 +3341,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b06bd918d60111ee1f97de817113e2040ca0cedb740099ee8d646233f6b906c"
 dependencies = [
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
 ]
 
 [[package]]
@@ -3389,7 +3389,7 @@ dependencies = [
  "serde_json",
  "solana-account",
  "solana-account-decoder-client-types",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-fee-calculator",
@@ -3432,7 +3432,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
 ]
 
 [[package]]
@@ -3717,7 +3717,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
@@ -3787,7 +3787,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-sdk-ids",
 ]
 
@@ -3800,7 +3800,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-hash 4.2.0",
  "solana-instruction",
  "solana-instruction-error",
@@ -3978,7 +3978,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-address 2.2.0",
+ "solana-address 2.5.0",
  "solana-derivation-path",
  "solana-instruction",
  "solana-sdk-ids",
@@ -4006,6 +4006,7 @@ version = "0.23.0"
 dependencies = [
  "bincode",
  "derive_more",
+ "five8_core 1.0.0",
  "pyo3",
  "serde",
  "solana-address-lookup-table-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bincode = { workspace = true }
 derive_more = { workspace = true }
+# Force five8_core 1.0 (impls Error for DecodeError unconditionally). Otherwise
+# five8 1.0's over-wide range can resolve five8_core to the no_std 0.1.2, whose
+# Error impl is feature-gated off, which breaks solana-keypair.
+five8_core = "1"
 pyo3 = { workspace = true, features = ["macros", "extension-module", "abi3-py310"] }
 serde = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }


### PR DESCRIPTION
Updates litesvm 0.13.0 to 0.13.1, which refreshes the simulated mainnet feature set to match the cluster as of 2026-06-30 (adds sbpf_v3 deployment/execution, syscall parameter address restrictions, delayed commission updates, chained block id validation, and bpf stake program v5). This affects `LiteSVM.with_mainnet_features` / `mainnet_feature_set`.

### The `five8_core` line

litesvm 0.13.1 loosened its dependency pins. As a side effect, `five8 1.0`'s over-wide `five8_core >=0.1.1,<2` range resolves to the `no_std` `five8_core 0.1.2`, whose `impl Error for DecodeError` is gated behind a `std` feature that nothing enables. That leaves `DecodeError` without an `Error` impl and breaks `solana-keypair`, which calls `five8::decode_64(...).map_err(SignatureError::from_source)`.

Forcing `five8_core = "1"` pins that slot to `five8_core 1.0`, which impls `Error` unconditionally. This is the version litesvm 0.13.0 already resolved to, so it restores the working state rather than introducing anything new.
