### PR TITLE
rpc: Advertise base64 encoding on send/simulate when config is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# Unreleased
+
+### Fixed
+
+- `sendTransaction` / `simulateTransaction` request builders always advertise `encoding: "base64"` on the wire. The payload is serialized as base64 even when `config` is omitted, but JSON-RPC then defaults to base58 and the node rejects the request (`invalid base58 encoding`).
+
+### Changed
+
+- Omitting `config` on those builders now stores `Rpc*Config()` (so `req.config` is no longer `None`). `RpcSendTransactionConfig.default()` / `RpcSimulateTransactionConfig.default()` now match `Rpc*Config()` instead of leaving `encoding` unset.
+
 # [0.29.0] - 2026-08-13
 
 ### Added

--- a/crates/rpc-requests/src/lib.rs
+++ b/crates/rpc-requests/src/lib.rs
@@ -2191,7 +2191,8 @@ impl SendVersionedTransaction {
         config: Option<RpcSendTransactionConfig>,
         id: Option<u64>,
     ) -> Self {
-        let params = SendTransactionParams(tx, config);
+        let params =
+            SendTransactionParams(tx, Some(RpcSendTransactionConfig::for_json_rpc(config)));
         let base = RequestBase::new(id);
         Self { base, params }
     }
@@ -2259,7 +2260,8 @@ impl SendLegacyTransaction {
     #[new]
     #[pyo3(signature = (tx, config=None, id=None))]
     fn new(tx: Transaction, config: Option<RpcSendTransactionConfig>, id: Option<u64>) -> Self {
-        let params = SendTransactionParams(tx, config);
+        let params =
+            SendTransactionParams(tx, Some(RpcSendTransactionConfig::for_json_rpc(config)));
         let base = RequestBase::new(id);
         Self { base, params }
     }
@@ -2326,7 +2328,8 @@ impl SendRawTransaction {
     #[new]
     #[pyo3(signature = (tx, config=None, id=None))]
     fn new(tx: Vec<u8>, config: Option<RpcSendTransactionConfig>, id: Option<u64>) -> Self {
-        let params = SendTransactionParams(tx, config);
+        let params =
+            SendTransactionParams(tx, Some(RpcSendTransactionConfig::for_json_rpc(config)));
         let base = RequestBase::new(id);
         Self { base, params }
     }
@@ -2396,7 +2399,8 @@ impl SimulateLegacyTransaction {
     #[new]
     #[pyo3(signature = (tx, config=None, id=None))]
     fn new(tx: Transaction, config: Option<RpcSimulateTransactionConfig>, id: Option<u64>) -> Self {
-        let params = SimulateTransactionParams(tx, config);
+        let params =
+            SimulateTransactionParams(tx, Some(RpcSimulateTransactionConfig::for_json_rpc(config)));
         let base = RequestBase::new(id);
         Self { base, params }
     }
@@ -2470,7 +2474,8 @@ impl SimulateVersionedTransaction {
         config: Option<RpcSimulateTransactionConfig>,
         id: Option<u64>,
     ) -> Self {
-        let params = SimulateTransactionParams(tx, config);
+        let params =
+            SimulateTransactionParams(tx, Some(RpcSimulateTransactionConfig::for_json_rpc(config)));
         let base = RequestBase::new(id);
         Self { base, params }
     }

--- a/crates/rpc-send-transaction-config/src/lib.rs
+++ b/crates/rpc-send-transaction-config/src/lib.rs
@@ -84,6 +84,20 @@ impl RpcSendTransactionConfig {
     #[staticmethod]
     #[pyo3(name = "default")]
     pub fn new_default() -> Self {
-        Self::default()
+        Self::new(false, None, None, None)
+    }
+}
+
+impl RpcSendTransactionConfig {
+    /// Fill `encoding: base64` when the config is omitted or left unset.
+    ///
+    /// JSON-RPC `sendTransaction` defaults to base58 if encoding is missing, but solders
+    /// always serializes the payload as base64.
+    pub fn for_json_rpc(config: Option<Self>) -> Self {
+        let mut cfg = config.unwrap_or_else(|| Self::new(false, None, None, None));
+        if cfg.0.encoding.is_none() {
+            cfg.0.encoding = Some(UiTransactionEncodingOriginal::Base64);
+        }
+        cfg
     }
 }

--- a/crates/rpc-sim-transaction-config/src/lib.rs
+++ b/crates/rpc-sim-transaction-config/src/lib.rs
@@ -33,7 +33,7 @@ pyclass_boilerplate_with_default!(
 impl RpcSimulateTransactionConfig {
     #[new]
     #[pyo3(signature = (sig_verify=false, replace_recent_blockhash=false, commitment=None, accounts=None, min_context_slot=None, inner_instructions=false))]
-    fn new(
+    pub fn new(
         sig_verify: bool,
         replace_recent_blockhash: bool,
         commitment: Option<CommitmentLevel>,
@@ -59,7 +59,7 @@ impl RpcSimulateTransactionConfig {
     #[staticmethod]
     #[pyo3(name = "default")]
     fn new_default() -> Self {
-        Self::default()
+        Self::new(false, false, None, None, None, false)
     }
 
     #[getter]
@@ -95,5 +95,19 @@ impl RpcSimulateTransactionConfig {
     #[getter]
     pub fn inner_instructions(&self) -> bool {
         self.0.inner_instructions
+    }
+}
+
+impl RpcSimulateTransactionConfig {
+    /// Fill `encoding: base64` when the config is omitted or left unset.
+    ///
+    /// JSON-RPC `simulateTransaction` defaults to base58 if encoding is missing, but solders
+    /// always serializes the payload as base64.
+    pub fn for_json_rpc(config: Option<Self>) -> Self {
+        let mut cfg = config.unwrap_or_else(|| Self::new(false, false, None, None, None, false));
+        if cfg.0.encoding.is_none() {
+            cfg.0.encoding = Some(UiTransactionEncodingOriginal::Base64);
+        }
+        cfg
     }
 }

--- a/tests/test_rpc_send_simulate_encoding.py
+++ b/tests/test_rpc_send_simulate_encoding.py
@@ -1,0 +1,116 @@
+"""send/simulate requests must advertise base64 when the config is omitted.
+
+The transaction payload is always base64. JSON-RPC defaults to base58 if the
+config object is missing or has encoding=null, which real nodes reject.
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+from typing import Any
+
+from solders.hash import Hash
+from solders.instruction import Instruction
+from solders.keypair import Keypair
+from solders.message import Message
+from solders.pubkey import Pubkey
+from solders.rpc.config import RpcSendTransactionConfig, RpcSimulateTransactionConfig
+from solders.rpc.requests import (
+    GetClusterNodes,
+    SendLegacyTransaction,
+    SendRawTransaction,
+    SendVersionedTransaction,
+    SimulateLegacyTransaction,
+    SimulateVersionedTransaction,
+    batch_to_json,
+)
+from solders.transaction import Transaction, VersionedTransaction
+from solders.transaction_status import UiTransactionEncoding
+
+SEED = bytes([1] * 32)
+BLOCKHASH = Hash.default()
+PROGRAM_ID = Pubkey.default()
+
+
+def _legacy_tx() -> Transaction:
+    payer = Keypair.from_seed(SEED)
+    ix = Instruction(PROGRAM_ID, b"abc", [])
+    message = Message([ix], payer.pubkey())
+    return Transaction([payer], message, BLOCKHASH)
+
+
+def _versioned_tx() -> VersionedTransaction:
+    payer = Keypair.from_seed(SEED)
+    ix = Instruction(PROGRAM_ID, b"abc", [])
+    message = Message.new_with_blockhash([ix], payer.pubkey(), BLOCKHASH)
+    return VersionedTransaction(message, [payer])
+
+
+def _assert_base64_payload(payload: dict[str, Any]) -> None:
+    params = payload["params"]
+    assert len(params) >= 2
+    tx_b64 = params[0]
+    assert isinstance(tx_b64, str)
+    assert any(ch in tx_b64 for ch in "+/")
+    assert params[1]["encoding"] == "base64"
+
+
+def test_omitted_config_uses_python_ctor_defaults_with_base64() -> None:
+    legacy = _legacy_tx()
+    versioned = _versioned_tx()
+    raw = bytes(legacy)
+    cases = [
+        SendLegacyTransaction(legacy),
+        SendVersionedTransaction(versioned),
+        SendRawTransaction(raw),
+        SimulateLegacyTransaction(legacy),
+        SimulateVersionedTransaction(versioned),
+    ]
+    for req in cases:
+        assert req.config is not None
+        assert req.config.encoding == UiTransactionEncoding.Base64
+        payload = json.loads(req.to_json())
+        assert payload["method"] in {"sendTransaction", "simulateTransaction"}
+        _assert_base64_payload(payload)
+        restored = type(req).from_bytes(bytes(req))
+        assert restored == req
+        assert pickle.loads(pickle.dumps(req)) == req
+
+
+def test_python_default_now_matches_ctor_encoding() -> None:
+    send_default = RpcSendTransactionConfig.default()
+    sim_default = RpcSimulateTransactionConfig.default()
+    assert send_default.encoding == UiTransactionEncoding.Base64
+    assert sim_default.encoding == UiTransactionEncoding.Base64
+    assert send_default == RpcSendTransactionConfig()
+    assert sim_default == RpcSimulateTransactionConfig()
+
+
+def test_python_ctor_config_keeps_existing_fields() -> None:
+    legacy = _legacy_tx()
+    send_cfg = RpcSendTransactionConfig(skip_preflight=True)
+    sim_cfg = RpcSimulateTransactionConfig(sig_verify=True)
+    send_payload = json.loads(SendRawTransaction(bytes(legacy), send_cfg).to_json())
+    assert send_payload["params"][1]["encoding"] == "base64"
+    assert send_payload["params"][1]["skipPreflight"] is True
+    sim_payload = json.loads(SimulateLegacyTransaction(legacy, sim_cfg).to_json())
+    assert sim_payload["params"][1]["encoding"] == "base64"
+    assert sim_payload["params"][1]["sigVerify"] is True
+
+
+def test_batch_to_json_fills_encoding_and_leaves_neighbors_alone() -> None:
+    legacy = _legacy_tx()
+    versioned = _versioned_tx()
+    batch = json.loads(
+        batch_to_json(
+            [
+                GetClusterNodes(0),
+                SendLegacyTransaction(legacy),
+                SimulateVersionedTransaction(versioned),
+            ]
+        )
+    )
+    assert batch[0] == json.loads(GetClusterNodes(0).to_json())
+    _assert_base64_payload(batch[1])
+    _assert_base64_payload(batch[2])

--- a/tests/test_rpc_send_simulate_encoding.py
+++ b/tests/test_rpc_send_simulate_encoding.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import pickle
-from typing import Any
+from typing import Any, List, Union, cast
 
 from solders.hash import Hash
 from solders.instruction import Instruction
@@ -60,7 +60,15 @@ def test_omitted_config_uses_python_ctor_defaults_with_base64() -> None:
     legacy = _legacy_tx()
     versioned = _versioned_tx()
     raw = bytes(legacy)
-    cases = [
+    cases: List[
+        Union[
+            SendLegacyTransaction,
+            SendVersionedTransaction,
+            SendRawTransaction,
+            SimulateLegacyTransaction,
+            SimulateVersionedTransaction,
+        ]
+    ] = [
         SendLegacyTransaction(legacy),
         SendVersionedTransaction(versioned),
         SendRawTransaction(raw),
@@ -73,7 +81,7 @@ def test_omitted_config_uses_python_ctor_defaults_with_base64() -> None:
         payload = json.loads(req.to_json())
         assert payload["method"] in {"sendTransaction", "simulateTransaction"}
         _assert_base64_payload(payload)
-        restored = type(req).from_bytes(bytes(req))
+        restored = cast(Any, type(req)).from_bytes(bytes(req))
         assert restored == req
         assert pickle.loads(pickle.dumps(req)) == req
 


### PR DESCRIPTION
## Problem

`SimulateVersionedTransaction(tx)`, `SimulateLegacyTransaction(tx)`, `SendVersionedTransaction(tx)`, `SendLegacyTransaction(tx)` and `SendRawTransaction(raw)` always serialize the transaction as base64 (`FromInto<Base64String>`). When `config` is omitted, `skip_serializing_none` drops the config object, so a real node applies the JSON-RPC default of **base58**.

Against `https://api.devnet.solana.com` on 0.29.0:

```
SimulateVersionedTransaction(tx).to_json()
# params: [<base64>]   (no config)

RPC: {"error":{"code":-32602,"message":"invalid base58 encoding: InvalidCharacter { character: '+', ...}"}}
```

Passing `RpcSimulateTransactionConfig()` / `RpcSendTransactionConfig()` works, because those constructors hardcode `encoding: base64`. `Rpc*Config.default()` did not: it left `encoding` unset, so the same -32602 happened even with an explicit config object.

Doctests never caught this because they always pass a constructor-built config.

This is not a solana-py bug. High-level solana-py send/simulate already construct `Rpc*Config(...)`. It is a solders request-builder footgun for anyone calling the builders without a config.

## Fix

- `Send*` / `Simulate*` constructors store `Rpc*Config()` when config is omitted, so the wire always includes `encoding: "base64"`.
- `for_json_rpc` also fills encoding if a provided config has it unset.
- Python `RpcSendTransactionConfig.default()` / `RpcSimulateTransactionConfig.default()` now match `Rpc*Config()` instead of the Solana `Default` derive (`encoding: None`).

## Compatibility

Omitting `config` used to leave `req.config is None`. After this change it is `Rpc*Config()`. That is the same object the constructors already emit, so the wire grows the default fields (`sigVerify`/`skipPreflight`/nulls) rather than a one-key `{encoding:base64}` object. Stated as Changed in the changelog.

## Tests

`tests/test_rpc_send_simulate_encoding.py`: omitted config, Python `default()`, field preservation, mixed `batch_to_json` with `GetClusterNodes`, pickle/`from_bytes` identity.

```
uv run pytest tests/test_rpc_send_simulate_encoding.py tests/test_rpc_request_builder.py tests/test_pickle.py
# 31 passed
```

Live against devnet after the change: omitted-config simulate is accepted (`AccountNotFound` on an unfunded payer, not -32602). Send likewise gets past encoding into a simulation failure.

Modeled on #167 (wrong Optional type) / #154 (missing compute-budget helper): small usage-discovered plumbing, tests, no drive-by.